### PR TITLE
Enable the stricter runtime sanitization checks with `-DDEBUG`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,9 @@ if(COVERAGE)
 endif()
 
 # Add Debugging flags to scone library
+# NOTE: GFortran 7.5 may give buggy warnings here
+#   If this is an issue, consider using `-fcheck=bounds,do,mem,pointer`
+#   https://github.com/CambridgeNuclear/SCONE/pull/15#issuecomment-1384192425
 if(DEBUG)
   list(APPEND scone_extra_flags "-fcheck=all,no-array-temps" "-Waliasing")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 
 # Add Debugging flags to scone library
 if(DEBUG)
-  list(APPEND scone_extra_flags "-fcheck=bounds,do,mem,pointer" "-Waliasing")
+  list(APPEND scone_extra_flags "-fcheck=all" "-Waliasing")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 
 # Add Debugging flags to scone library
 if(DEBUG)
-  list(APPEND scone_extra_flags "-fcheck=all" "-Waliasing")
+  list(APPEND scone_extra_flags "-fcheck=all,no-array-temps" "-Waliasing")
 endif()
 
 

--- a/SharedModules/hashFunctions_func.f90
+++ b/SharedModules/hashFunctions_func.f90
@@ -53,7 +53,7 @@ contains
     hash_loc = iand( prime * key, mask)
 
     ! Keep m uppermost bits
-    hash = transfer(shiftr(hash_loc,32-m),shortInt)
+    hash = transfer(shiftr(hash_loc, 32 - m_loc),shortInt)
 
   end function knuthHash
 


### PR DESCRIPTION
The `hashFunctions` unit-tests failed when the extra runtime sanitation was enabled. This PR fixes the issue and enables the stricter checks in debug mode.

@ChasingNeutrons does this look reasonable?