### PR TITLE
Update SCONE ACE Library file

### DIFF
--- a/IntegrationTestFiles/testLib
+++ b/IntegrationTestFiles/testLib
@@ -1,19 +1,19 @@
-! ZAID    Line Number     PATH 
-92233.03c 1         ./IntegrationTestFiles/92233JEF311.ace 
+! ZAID    Line Number     PATH
+92233.03c; 1;         ./IntegrationTestFiles/92233JEF311.ace;
 
 
-1001.03c  1779      ./IntegrationTestFiles/1001JEF311.ace
+1001.03c;  1779;      ./IntegrationTestFiles/1001JEF311.ace;
 
-6012.06c  1         ./IntegrationTestFiles/6012JNDL32.ace
+6012.06c;  1;         ./IntegrationTestFiles/6012JNDL32.ace;
 
 
-! An extra comment line 
+! An extra comment line
 
-8016.03c  1       ./IntegrationTestFiles/8016JEF311.ace
+8016.03c;  1;       ./IntegrationTestFiles/8016JEF311.ace;
 
-92235.03c 1       ./IntegrationTestFiles/92235JEF311.ace 
+92235.03c; 1;       ./IntegrationTestFiles/92235JEF311.ace;
 
 ! Test S(alpha,beta) T = 323.6K
 
-h-h2o.49t   1 ./IntegrationTestFiles/h-h2o.49t
-grph30.46t  1 ./IntegrationTestFiles/grph30.46t
+h-h2o.49t;   1; ./IntegrationTestFiles/h-h2o.49t;
+grph30.46t;  1; ./IntegrationTestFiles/grph30.46t;

--- a/IntegrationTestFiles/testLib
+++ b/IntegrationTestFiles/testLib
@@ -1,8 +1,8 @@
 ! ZAID    Line Number     PATH
 92233.03c; 1;         ./IntegrationTestFiles/92233JEF311.ace;
 
-
-1001.03c;  1779;      ./IntegrationTestFiles/1001JEF311.ace;
+! We wish to make sure we support long paths
+1001.03c;  1779;      ./IntegrationTestFiles/../IntegrationTestFiles/../IntegrationTestFiles/../IntegrationTestFiles/../IntegrationTestFiles/../IntegrationTestFiles/../IntegrationTestFiles/1001JEF311.ace;
 
 6012.06c;  1;         ./IntegrationTestFiles/6012JNDL32.ace;
 

--- a/NuclearData/DataDecks/ACE/aceCard_class.f90
+++ b/NuclearData/DataDecks/ACE/aceCard_class.f90
@@ -1434,16 +1434,13 @@ contains
     character(*), intent(in)       :: filePath
     integer(shortInt), intent(in)  :: lineNum
     integer(shortInt)              :: aceFile = 8
-    character(pathLen)             :: localFilePath
     integer(shortInt)              :: i, xssLen
     character(13)                  :: skip
     character(100),parameter :: Here ='readFromFile (aceCard_class.f90)'
 
-    ! Copy filepath and make sure it is left adjusted
-    localFilePath = trim(adjustl(filePath))
-
     ! Open file to read data
-    call openToRead(aceFile,localFilePath)
+    ! If a path has whitespace at LHS, file will fail to open. We need to trim the whitespace.
+    call openToRead(aceFile, adjustl(filePath))
 
     ! Skip lines
     select case(lineNum)

--- a/NuclearData/ceNeutronData/aceLibrary_mod.f90
+++ b/NuclearData/ceNeutronData/aceLibrary_mod.f90
@@ -40,10 +40,10 @@ module aceLibrary_mod
   !! Storage for data associated with each library entry
   !!
   type, private :: item
-    character(nameLen) :: ZAID
-    integer(shortInt)  :: firstLine = 1
-    integer(shortInt)  :: type = UNDEF
-    character(pathLen) :: path
+    character(nameLen)        :: ZAID
+    integer(shortInt)         :: firstLine = 1
+    integer(shortInt)         :: type = UNDEF
+    character(:), allocatable :: path
   end type
 
 !!<><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
@@ -52,7 +52,7 @@ module aceLibrary_mod
 
   type(item),dimension(:),allocatable :: entry
   type(charMap)                       :: map
-  character(pathLen)                  :: libFile
+  character(:), allocatable           :: libFile
 
   public :: load
   public :: new_neutronACE
@@ -249,7 +249,7 @@ contains
 
     if(allocated(entry)) deallocate(entry)
     call map % kill()
-    libFile = ''
+    if(allocated(libFile)) deallocate(libFile)
 
   end subroutine kill
 

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -261,14 +261,27 @@ its own library file. An example of it is given in *IntegrationTestFiles/testLib
   ! This is a comment line
   ! Each line needs to contain three entries
   ! ZAID   Line Number   PATH
-  92233.03c  1       <absolute_path>/9233JEF33.ace
-  1001.03c   4069    <absolute_path>/1001JEF33.ace
+  92233.03c;  1;       <absolute_path>/9233JEF33.ace;
+  1001.03c;   4069;    <absolute_path>/1001JEF33.ace;
   ...
 
 `Line Number` is the line in the file at which a particular data card begins. Each line cannot
-contain more then a single entry. Each component must be space separated. Path can have only 100
-character and contain no spaces.
+contain more then a single entry. Each component must be delimited by a semi-colon.
 
-Soon the format of the file will be changes to allow spaces in the path. Also the limitation on its
-length will be lifted. A script will be included in ``cream`` to generate the library file directly
-from the ACE files.
+To generate the library file from the collection of raw ACE files one can use the
+``scripts/make_ace_lib.sh`` bash script. It can be run with the following command:
+
+.. code-block:: bash
+
+  ./scripts/make_ace_lib.sh /path/lib.xsfile CE ./path_to_ace_files/*.ace
+
+To get extra help run the script without any arguments. The ``CE`` letters allow to select between
+searching for continuous energy neutron data cards and thermal scattering S(α,β) cards (SAB mode).
+Sadly the script can search only for a single type of card in one pass. Thus to create a full
+library with thermal data we need to do the following:
+
+.. code-block:: bash
+
+  ./scripts/make_ace_lib.sh ./tempCE CE ./path_to_CE_ace_files/*.ace
+  ./scripts/make_ace_lib.sh ./tempSAB SAB ./path_to_SAB_ace_files/*.ace
+  cat tempCE tempSAB > fullLib.xsfile

--- a/scripts/make_ace_lib.sh
+++ b/scripts/make_ace_lib.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+HELP="Create a SCONE nuclear data library file from raw ACE Neutron CE files.
+
+make_ace_lib.sh <output> <MODE> <ace-file>+
+
+Arguments:
+  <output>  Library file to create.
+  <MODE>    Choose tosearch for CE Neutron cards (ZZAAA.TTc id). or SAB cards (XXXXXX.TTt)
+  <ace-files>  List of files to search for the ID pattern
+
+The script searches each of the <ace-file> for a presence of an ID pattern (ZZAAA.TTc for CE;
+XXXXXX.TTt for SAB card) at a beginning of the line. By ACE definition this should match only
+a first line of a header of an ACE card. For each match the script prints a line of the SCONE
+nuclear data library file to <output> as:
+  ZAID; LINE_NUMBER; FILE;
+  ...
+"
+
+# Display help if number of arguments is wrong
+if [ $# -le 2 ]; then
+  echo "${HELP}"
+  exit 1
+fi
+
+# Pop first argument to be the library file
+OUTNAME=$1
+MODE=$2
+shift 2
+
+# If file already exists ask for confirmation and remove it
+if [ -f $OUTNAME ]; then
+  echo "Warning: File ${OUTNAME} exists and will be overriden."
+  read -p "Continue [Y/n]? "  -r
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    exit 1
+  fi
+  rm $OUTNAME
+fi
+
+# Process each ACE file with awk
+for var in $@
+do
+  if [ ! -f $var ]; then
+    echo -e "File '${var}' does not exist \U0001F61E"
+    echo -e "Quitting \U0001F44B"
+    exit 1
+  fi
+
+  # We need full path to put in the file
+  FULL_PATH=$(realpath $var)
+
+  echo "Processing file ${var}"
+  if [[ $MODE =~ ^CE$ ]]; then
+    awk -v FILE=$FULL_PATH \
+    '/^[[:space:]]*[[:digit:]][[:digit:]][[:digit:]][[:digit:]][[:digit:]]?.[[:digit:]][[:digit:]]c/\
+      {print $1 "; " NR "; " FILE "; "}' $var >> $OUTNAME
+
+  elif [[ $MODE =~ ^SAB$ ]]; then
+    awk -v FILE=$FULL_PATH \
+    '/^[[:space:]]*[[:alnum:]]+.[[:digit:]][[:digit:]]t/\
+      {print $1 "; " NR "; " FILE "; "}' $var >> $OUTNAME
+
+  else
+    echo "Unknown mode '${MODE}'. Must be CE or SAB"
+    exit 1
+  fi
+
+done


### PR DESCRIPTION
This PR makes couple of modifications to the ACE library file. 
- Delimiters are changed from space to semi-colon to allow paths with spaces 
- Limitation on the length of absolute path to an ACE file is removed (in practice determined only by the size of the buffer character to read lines [900 characters at the moment?]) 
- Adds a bash script to search ASCII files for first lines of ACE cards, which writes the library file in SCONE's format. 

If this PR is integrated it will of course break backwards compatibility with existing 'Library Files'. However thanks to the script generating new ones should not be the problem. 

One limitation is that path to the library file itself still cannot contain a space (as a space would confuse the input dictionary parsing... but technically it should be circumvented by using the environmental variable to specify library file path) 