### PR TITLE
Uniform Fission Sites

### DIFF
--- a/CollisionOperator/CollisionProcessors/neutronCEimp_class.f90
+++ b/CollisionOperator/CollisionProcessors/neutronCEimp_class.f90
@@ -346,7 +346,7 @@ contains
     type(neutronMicroXSs)                :: microXSs
     type(fissionCE), pointer             :: fiss
     type(particleState)                  :: pTemp
-    real(defReal),dimension(3)           :: r, dir
+    real(defReal),dimension(3)           :: r, dir, val
     integer(shortInt)                    :: n, i
     real(defReal)                        :: wgt, rand1, E_out, mu, phi
     real(defReal)                        :: sig_nufiss, sig_fiss, k_eff

--- a/CollisionOperator/CollisionProcessors/neutronCEimp_class.f90
+++ b/CollisionOperator/CollisionProcessors/neutronCEimp_class.f90
@@ -26,6 +26,10 @@ module neutronCEimp_class
   use neutronScatter_class,          only : neutronScatter, neutronScatter_TptrCast
   use fissionCE_class,               only : fissionCE, fissionCE_TptrCast
 
+  ! Geometry and fields
+  use geometryReg_mod,                only : gr_fieldIdx => fieldIdx, gr_fieldPtr => fieldPtr
+  use uniFissSitesField_class,        only : uniFissSitesField, uniFissSitesField_TptrCast
+
   ! Cross-Section Packages
   use neutronXsPackages_class,       only : neutronMicroXSs
 
@@ -51,6 +55,7 @@ module neutronCEimp_class
   !!  avgWgt  -> weight of a particle on surviving splitting (optional)
   !!  impAbs  -> is implicit capture performed? (off by default)
   !!  impGen  -> are fission sites generated implicitly? (on by default)
+  !!  UFS     -> uniform fission sites variance reduction
   !!  splitting -> splits particles above certain weight (on by default)
   !!  roulette  -> roulettes particles below certain weight (off by defautl)
   !!  thresh_E -> Energy threshold for explicit treatment of target nuclide movement [-].
@@ -61,18 +66,19 @@ module neutronCEimp_class
   !!
   !! Sample dictionary input:
   !!   collProcName {
-  !!   type             neutronCEimp;
-  !!   #minEnergy       <real>;#
-  !!   #maxEnergy       <real>;#
-  !!   #energyThreshold <real>;#
-  !!   #massThreshold   <real>;#
-  !!   #splitting       <logical>;#
-  !!   #roulette        <logical>;#
-  !!   #minWgt          <real>;#
-  !!   #maxWgt          <real>;#
-  !!   #avgWgt          <real>;#
-  !!   #impAbs          <logical>;#
-  !!   #impGen          <logical>;#
+  !!   type            neutronCEimp;
+  !!   #minEnergy      <real>;#
+  !!   #maxEnergy      <real>;#
+  !!   #energyTreshold <real>;#
+  !!   #massTreshold   <real>;#
+  !!   #splitting      <logical>;#
+  !!   #roulette       <logical>;#
+  !!   #minWgt         <real>;#
+  !!   #maxWgt         <real>;#
+  !!   #avgWgt         <real>;#
+  !!   #impAbs         <logical>;#
+  !!   #impGen         <logical>;#
+  !!   #UFS            <logical>;#
   !!   }
   !!
   type, public, extends(collisionProcessor) :: neutronCEimp
@@ -81,6 +87,7 @@ module neutronCEimp_class
     class(ceNeutronDatabase), pointer, public :: xsData => null()
     class(ceNeutronMaterial), pointer, public :: mat    => null()
     class(ceNeutronNuclide),  pointer, public :: nuc    => null()
+    class(uniFissSitesField), pointer :: UFSfield => null()
 
     !! Settings - private
     real(defReal) :: minE
@@ -95,6 +102,7 @@ module neutronCEimp_class
     logical(defBool) :: roulette
     logical(defBool) :: implicitAbsorption ! Prevents particles dying through capture
     logical(defBool) :: implicitSites ! Generates fission sites on every fissile collision
+    logical(defBool) :: uniFissSites
 
   contains
     ! Initialisation procedure
@@ -127,6 +135,8 @@ contains
   subroutine init(self, dict)
     class(neutronCEimp), intent(inout) :: self
     class(dictionary), intent(in)      :: dict
+    integer(shortInt)                  :: idx
+    character(nameLen)                 :: name
     character(100), parameter :: Here = 'init (neutronCEimp_class.f90)'
 
     ! Call superclass
@@ -149,6 +159,7 @@ contains
     call dict % getOrDefault(self % avWgt,'avWgt',0.5_defReal)
     call dict % getOrDefault(self % implicitAbsorption,'impAbs', .false.)
     call dict % getOrDefault(self % implicitSites,'impGen', .true.)
+    call dict % getOrDefault(self % uniFissSites,'UFS', .false.)
 
     ! Verify settings
     if( self % minE < ZERO ) call fatalError(Here,'-ve minEnergy')
@@ -166,6 +177,13 @@ contains
          'Must use Russian roulette when using implicit absorption')
       if (.not.self % implicitSites) call fatalError(Here,&
          'Must generate fission sites implicitly when using implicit absorption')
+    end if
+
+    ! Sets up the uniform fission sites field
+    if (self % uniFissSites) then
+      name = 'UFS'
+      idx = gr_fieldIdx(name)
+      self % UFSfield => uniFissSitesField_TptrCast(gr_fieldPtr(idx))
     end if
 
   end subroutine init
@@ -221,9 +239,9 @@ contains
     type(fissionCE), pointer             :: fission
     type(neutronMicroXSs)                :: microXSs
     type(particleState)                  :: pTemp
-    real(defReal),dimension(3)           :: r, dir
+    real(defReal),dimension(3)           :: r, dir, val
     integer(shortInt)                    :: n, i
-    real(defReal)                        :: wgt, w0, rand1, E_out, mu, phi
+    real(defReal)                        :: wgt, rand1, E_out, mu, phi
     real(defReal)                        :: sig_nufiss, sig_tot, k_eff, &
                                             sig_scatter, totalElastic
     logical(defBool)                     :: fiss_and_implicit
@@ -234,7 +252,6 @@ contains
     if (fiss_and_implicit) then
       ! Obtain required data
       wgt   = p % w                ! Current weight
-      w0    = p % preHistory % wgt ! Starting weight
       k_eff = p % k_eff            ! k_eff for normalisation
       rand1 = p % pRNG % get()     ! Random number to sample sites
 
@@ -244,7 +261,14 @@ contains
 
       ! Sample number of fission sites generated
       ! Support -ve weight particles
-      n = int(abs( (wgt * sig_nufiss) / (w0 * sig_tot * k_eff)) + rand1, shortInt)
+      if (self % uniFissSites) then
+        val = self % UFSfield % at(p)
+        n = int(abs( (wgt * sig_nufiss) / (sig_tot * k_eff))*val(1)/val(2) + rand1, shortInt)
+        wgt =  val(2)/val(1)
+      else
+        n = int(abs( (wgt * sig_nufiss) / (sig_tot * k_eff)) + rand1, shortInt)
+        wgt =  sign(ONE, wgt)
+      end if
 
       ! Shortcut particle generation if no particles were sampled
       if (n < 1) return
@@ -254,7 +278,6 @@ contains
       if(.not.associated(fission)) call fatalError(Here, "Failed to get fissionCE")
 
       ! Store new sites in the next cycle dungeon
-      wgt =  sign(w0, wgt)
       r   = p % rGlobal()
 
       do i=1,n
@@ -273,6 +296,8 @@ contains
         pTemp % wgt = wgt
 
         call nextCycle % detain(pTemp)
+        if (self % uniFissSites) call self % UFSfield % storeFS(pTemp)
+
       end do
     end if
 
@@ -323,14 +348,13 @@ contains
     type(particleState)                  :: pTemp
     real(defReal),dimension(3)           :: r, dir
     integer(shortInt)                    :: n, i
-    real(defReal)                        :: wgt, w0, rand1, E_out, mu, phi
+    real(defReal)                        :: wgt, rand1, E_out, mu, phi
     real(defReal)                        :: sig_nufiss, sig_fiss, k_eff
     character(100),parameter             :: Here = 'fission (neutronCEimp_class.f90)'
 
     if (.not.self % implicitSites) then
       ! Obtain required data
       wgt   = p % w                ! Current weight
-      w0    = p % preHistory % wgt ! Starting weight
       k_eff = p % k_eff            ! k_eff for normalisation
       rand1 = p % pRNG % get()     ! Random number to sample sites
 
@@ -341,7 +365,14 @@ contains
       ! Sample number of fission sites generated
       ! Support -ve weight particles
       ! Note change of denominator (sig_fiss) wrt implicit generation
-      n = int(abs( (wgt * sig_nufiss) / (w0 * sig_fiss * k_eff)) + rand1, shortInt)
+      if (self % uniFissSites) then
+        val = self % UFSfield % at(p)
+        n = int(abs( (wgt * sig_nufiss) / (sig_fiss * k_eff))*val(1)/val(2) + rand1, shortInt)
+        wgt =  val(2)/val(1)
+      else
+        n = int(abs( (wgt * sig_nufiss) / (sig_fiss * k_eff)) + rand1, shortInt)
+        wgt =  sign(ONE, wgt)
+      end if
 
       ! Shortcut particle generation if no particles were sampled
       if (n < 1) return
@@ -351,7 +382,6 @@ contains
       if(.not.associated(fiss)) call fatalError(Here, "Failed to get fissionCE")
 
       ! Store new sites in the next cycle dungeon
-      wgt =  sign(w0, wgt)
       r   = p % rGlobal()
 
       do i=1,n
@@ -485,10 +515,20 @@ contains
     class(neutronCEimp), intent(inout)    :: self
     class(particle), intent(inout)        :: p
     class(particleDungeon), intent(inout) :: thisCycle
-    integer(shortInt)                     :: mult,i
+    integer(shortInt)                     :: mult, i, n
+    real(defReal)                         :: prob
 
-    ! This value must be at least 2
-    mult = ceiling(p % w/self % maxWgt)
+    n = floor(p % w/self % maxWgt)
+    prob = p % w/self % maxWgt - n
+
+    if (p % pRNG % get() < prob) then
+      mult = n + 1
+    else
+      mult = n
+    end if
+
+    if (mult == 1) return
+
     p % w = p % w/mult
 
     ! Add split particle's to the dungeon

--- a/CollisionOperator/CollisionProcessors/neutronCEimp_class.f90
+++ b/CollisionOperator/CollisionProcessors/neutronCEimp_class.f90
@@ -87,7 +87,7 @@ module neutronCEimp_class
     class(ceNeutronDatabase), pointer, public :: xsData => null()
     class(ceNeutronMaterial), pointer, public :: mat    => null()
     class(ceNeutronNuclide),  pointer, public :: nuc    => null()
-    class(uniFissSitesField), pointer :: UFSfield => null()
+    class(uniFissSitesField), pointer :: ufsField => null()
 
     !! Settings - private
     real(defReal) :: minE
@@ -183,7 +183,7 @@ contains
     if (self % uniFissSites) then
       name = 'UFS'
       idx = gr_fieldIdx(name)
-      self % UFSfield => uniFissSitesField_TptrCast(gr_fieldPtr(idx))
+      self % ufsField => uniFissSitesField_TptrCast(gr_fieldPtr(idx))
     end if
 
   end subroutine init
@@ -262,7 +262,7 @@ contains
       ! Sample number of fission sites generated
       ! Support -ve weight particles
       if (self % uniFissSites) then
-        val = self % UFSfield % at(p)
+        val = self % ufsField % at(p)
         n = int(abs( (wgt * sig_nufiss) / (sig_tot * k_eff))*val(1)/val(2) + rand1, shortInt)
         wgt =  val(2)/val(1)
       else
@@ -296,7 +296,7 @@ contains
         pTemp % wgt = wgt
 
         call nextCycle % detain(pTemp)
-        if (self % uniFissSites) call self % UFSfield % storeFS(pTemp)
+        if (self % uniFissSites) call self % ufsField % storeFS(pTemp)
 
       end do
     end if
@@ -366,7 +366,7 @@ contains
       ! Support -ve weight particles
       ! Note change of denominator (sig_fiss) wrt implicit generation
       if (self % uniFissSites) then
-        val = self % UFSfield % at(p)
+        val = self % ufsField % at(p)
         n = int(abs( (wgt * sig_nufiss) / (sig_fiss * k_eff))*val(1)/val(2) + rand1, shortInt)
         wgt =  val(2)/val(1)
       else
@@ -400,6 +400,8 @@ contains
         pTemp % wgt = wgt
 
         call nextCycle % detain(pTemp)
+        if (self % uniFissSites) call self % ufsField % storeFS(pTemp)
+
       end do
     end if
 

--- a/CollisionOperator/CollisionProcessors/neutronCEimp_class.f90
+++ b/CollisionOperator/CollisionProcessors/neutronCEimp_class.f90
@@ -519,7 +519,7 @@ contains
     integer(shortInt)                     :: mult, i
 
     ! This value must be at least 2
-    mult = ceiling(p % w/maxWgt)
+    mult = ceiling(p % w/self % maxWgt)
 
     ! Decrease weight
     p % w = p % w/mult

--- a/CollisionOperator/CollisionProcessors/neutronCEimp_class.f90
+++ b/CollisionOperator/CollisionProcessors/neutronCEimp_class.f90
@@ -2,6 +2,7 @@ module neutronCEimp_class
 
   use numPrecision
   use endfConstants
+  use universalVariables,            only : nameUFS
   use genericProcedures,             only : fatalError, rotateVector, numToChar
   use dictionary_class,              only : dictionary
   use RNG_class,                     only : RNG
@@ -136,7 +137,6 @@ contains
     class(neutronCEimp), intent(inout) :: self
     class(dictionary), intent(in)      :: dict
     integer(shortInt)                  :: idx
-    character(nameLen)                 :: name
     character(100), parameter :: Here = 'init (neutronCEimp_class.f90)'
 
     ! Call superclass
@@ -181,8 +181,7 @@ contains
 
     ! Sets up the uniform fission sites field
     if (self % uniFissSites) then
-      name = 'UFS'
-      idx = gr_fieldIdx(name)
+      idx = gr_fieldIdx(nameUFS)
       self % ufsField => uniFissSitesField_TptrCast(gr_fieldPtr(idx))
     end if
 
@@ -517,20 +516,12 @@ contains
     class(neutronCEimp), intent(inout)    :: self
     class(particle), intent(inout)        :: p
     class(particleDungeon), intent(inout) :: thisCycle
-    integer(shortInt)                     :: mult, i, n
-    real(defReal)                         :: prob
+    integer(shortInt)                     :: mult, i
 
-    n = floor(p % w/self % maxWgt)
-    prob = p % w/self % maxWgt - n
+    ! This value must be at least 2
+    mult = ceiling(p % w/maxWgt)
 
-    if (p % pRNG % get() < prob) then
-      mult = n + 1
-    else
-      mult = n
-    end if
-
-    if (mult == 1) return
-
+    ! Decrease weight
     p % w = p % w/mult
 
     ! Add split particle's to the dungeon

--- a/Geometry/CMakeLists.txt
+++ b/Geometry/CMakeLists.txt
@@ -9,6 +9,8 @@ add_sources( ./csg_class.f90
              ./geometry_inter.f90
              ./geometryStd_class.f90
              ./geometryReg_mod.f90
+             ./geometryFactory_func.f90
+             ./fieldFactory_func.f90
            )
 
 add_unit_tests( ./Tests/geomGraph_test.f90

--- a/Geometry/Fields/ScalarFields/Tests/uniformScalarField_test.f90
+++ b/Geometry/Fields/ScalarFields/Tests/uniformScalarField_test.f90
@@ -2,7 +2,7 @@ module uniformScalarField_test
 
   use numPrecision
   use dictionary_class,         only : dictionary
-  use coord_class,              only : coordList
+  use particle_class,           only : particle
   use field_inter,              only : field
   use scalarField_inter,        only : scalarField, scalarField_CptrCast
   use uniformScalarField_class, only : uniformScalarField, uniformScalarField_TptrCast
@@ -22,7 +22,7 @@ contains
     class(scalarField), pointer       :: ptr
     type(uniformScalarField), pointer :: ptr2
     type(dictionary)                  :: dict
-    type(coordList)                   :: coords
+    type(particle)                    :: p
     real(defReal), parameter :: TOL = 1.0E-7_defReal
 
     ! Test invalid pointers
@@ -50,8 +50,7 @@ contains
     call fieldT % init(dict)
 
     ! Check value
-    call coords % init([ONE, ZERO, ONE], [ONE, ZERO, ZERO])
-    @assertEqual(9.6_defReal, fieldT % at(coords), TOL)
+    @assertEqual(9.6_defReal, fieldT % at(p), TOL)
 
     ! Kill
     call fieldT % kill()

--- a/Geometry/Fields/ScalarFields/scalarField_inter.f90
+++ b/Geometry/Fields/ScalarFields/scalarField_inter.f90
@@ -1,8 +1,8 @@
 module scalarField_inter
 
   use numPrecision
-  use field_inter, only : field
-  use coord_class, only : coordList
+  use field_inter,    only : field
+  use particle_class, only : particle
 
   implicit none
   private
@@ -38,10 +38,10 @@ module scalarField_inter
     !! Result:
     !!   Value of the scalar field. Real number.
     !!
-    function at(self, coords) result(val)
-      import :: scalarField, coordList, defReal
+    function at(self, p) result(val)
+      import :: scalarField, particle, defReal
       class(scalarField), intent(in) :: self
-      type(coordList), intent(in)    :: coords
+    class(particle), intent(inout)   :: p
       real(defReal)                  :: val
     end function at
 

--- a/Geometry/Fields/ScalarFields/uniformScalarField_class.f90
+++ b/Geometry/Fields/ScalarFields/uniformScalarField_class.f90
@@ -2,7 +2,7 @@ module uniformScalarField_class
 
   use numPrecision
   use dictionary_class,  only : dictionary
-  use coord_class,       only : coordList
+  use particle_class,    only : particle
   use field_inter,       only : field
   use scalarField_inter, only : scalarField
 
@@ -68,9 +68,9 @@ contains
   !!
   !! See scalarField_inter for details
   !!
-  function at(self, coords) result(val)
+  function at(self, p) result(val)
     class(uniformScalarField), intent(in) :: self
-    type(coordList), intent(in)           :: coords
+    class(particle), intent(inout)        :: p
     real(defReal)                         :: val
 
     val = self % val

--- a/Geometry/Fields/VectorFields/CMakeLists.txt
+++ b/Geometry/Fields/VectorFields/CMakeLists.txt
@@ -3,4 +3,5 @@ add_sources( ./vectorField_inter.f90
              ./uniformVectorField_class.f90
              ./uniFissSitesField_class.f90)
 
-add_unit_tests( ./Tests/uniformVectorField_test.f90)
+add_unit_tests( ./Tests/uniformVectorField_test.f90
+                ./Tests/uniFissSitesField_test.f90)

--- a/Geometry/Fields/VectorFields/CMakeLists.txt
+++ b/Geometry/Fields/VectorFields/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 add_sources( ./vectorField_inter.f90
-             ./uniformVectorField_class.f90)
+             ./uniformVectorField_class.f90
+             ./uniFissSitesField_class.f90)
 
 add_unit_tests( ./Tests/uniformVectorField_test.f90)

--- a/Geometry/Fields/VectorFields/Tests/uniFissSitesField_test.f90
+++ b/Geometry/Fields/VectorFields/Tests/uniFissSitesField_test.f90
@@ -1,0 +1,117 @@
+module uniFissSitesField_test
+  use numPrecision
+  use pFUnit_mod
+  use particle_class,           only : particle, particleState
+  use dictionary_class,         only : dictionary
+  use dictParser_func,          only : charToDict
+  use geometry_inter,           only : geometry
+  use RNG_class,                only : RNG
+  use uniFissSitesField_class,  only : uniFissSitesField
+
+  implicit none
+
+
+@testCase
+  type, extends(TestCase) :: test_uniFissSitesField
+    private
+    type(uniFissSitesField) :: ufsField
+  contains
+    procedure :: setUp
+    procedure :: tearDown
+  end type test_uniFissSitesField
+
+  !!
+  !! Map definition
+  !!
+  character(*), parameter :: DICT_DEF = &
+  " type spaceMap;  axis z;  grid unstruct; &
+    bins (0.0 20.0 40.0 60.0 80.0); "
+
+contains
+
+  !!
+  !! Sets up test_weightWindows object we can use in a number of tests
+  !!
+  subroutine setUp(this)
+    class(test_uniFissSitesField), intent(inout) :: this
+    type(dictionary)                             :: dict, dictMap
+    class(geometry), pointer                     :: geom
+    class(RNG), pointer                          :: rand
+    integer(shortInt)                            :: type
+
+    call charToDict(dictMap, DICT_DEF)
+
+    ! Initialise dictionaries
+    call dict % init(3)
+
+    ! Build material map definition
+    call dict % store('type', 'uniFissSitesField')
+    call dict % store('uniformMap', 1)
+    call dict % store('map', dictMap)
+
+    call this % ufsField % init(dict)
+    call this % ufsField % estimateVol(geom, rand, type)
+
+  end subroutine setUp
+
+  !!
+  !! Kills test_weightWindows object
+  !!
+  subroutine tearDown(this)
+    class(test_uniFissSitesField), intent(inout) :: this
+
+    call this % ufsField % kill()
+
+  end subroutine tearDown
+
+!!<><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+!! PROPER TESTS BEGIN HERE
+!!<><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+
+  !!
+  !! Test retrieving the ufs values
+  !!
+@Test
+  subroutine testGetValue(this)
+    class(test_uniFissSitesField), intent(inout) :: this
+    type(particle)                               :: p
+    type(particleState)                          :: state
+    integer(shortInt), dimension(3)              :: bins, EXPECTED_BINS
+
+    ! Test case in the map
+    p % coords % lvl(1) % r = [0.5, 7.0, 50.0]
+
+    bins = this % ufsField % at(p)
+    EXPECTED_BINS = [0.25, 0.25, 0.0]
+    @assertEqual(EXPECTED_BINS,bins)
+
+    ! Test case outside the map
+    p % coords % lvl(1) % r = [0.5, 7.0, 100.0]
+
+    bins = this % ufsField % at(p)
+    EXPECTED_BINS = [1.0, 1.0, 1.0]
+    @assertEqual(EXPECTED_BINS,bins)
+
+    ! Modify the map by storing fission sites
+    state % r   = [0.5, 7.0, 12.0]
+    state % wgt = 0.2
+
+    call this % ufsField % storeFS(state)
+
+    state % r   = [0.5, 7.0, 23.2]
+    state % wgt = 0.8
+    call this % ufsField % storeFS(state)
+
+    call this % ufsField % updateMap()
+
+    ! Test case in the updated map
+    p % coords % lvl(1) % r = [0.5, 7.0, 18.1]
+
+    bins = this % ufsField % at(p)
+    EXPECTED_BINS = [0.25, 0.06666666667, 0.0]
+    @assertEqual(EXPECTED_BINS,bins)
+
+  end subroutine testGetValue
+
+
+end module uniFissSitesField_test

--- a/Geometry/Fields/VectorFields/Tests/uniformVectorField_test.f90
+++ b/Geometry/Fields/VectorFields/Tests/uniformVectorField_test.f90
@@ -2,7 +2,7 @@ module uniformVectorField_test
 
   use numPrecision
   use dictionary_class,         only : dictionary
-  use coord_class,              only : coordList
+  use particle_class,           only : particle
   use field_inter,              only : field
   use vectorField_inter,        only : vectorField, vectorField_CptrCast
   use uniformVectorField_class, only : uniformVectorField, uniformVectorField_TptrCast
@@ -22,7 +22,7 @@ contains
     class(vectorField), pointer       :: ptr
     type(uniformVectorField), pointer :: ptr2
     type(dictionary)                  :: dict
-    type(coordList)                   :: coords
+    type(particle)                    :: p
     real(defReal), parameter :: TOL = 1.0E-7_defReal
 
     ! Test invalid pointers
@@ -50,8 +50,7 @@ contains
     call fieldT % init(dict)
 
     ! Check value
-    call coords % init([ONE, ZERO, ONE], [ONE, ZERO, ZERO])
-    @assertEqual([9.6_defReal, -8.0_defReal, 9.7_defReal], fieldT % at(coords), TOL)
+    @assertEqual([9.6_defReal, -8.0_defReal, 9.7_defReal], fieldT % at(p), TOL)
 
     ! Kill
     call fieldT % kill()

--- a/Geometry/Fields/VectorFields/uniFissSitesField_class.f90
+++ b/Geometry/Fields/VectorFields/uniFissSitesField_class.f90
@@ -197,6 +197,7 @@ contains
           if (.not. mat % isFissile()) cycle rejection
 
           state % r = r
+          state % matIdx = matIdx
 
           ! Read map bin index
           binIdx = self % map % map(state)

--- a/Geometry/Fields/VectorFields/uniFissSitesField_class.f90
+++ b/Geometry/Fields/VectorFields/uniFissSitesField_class.f90
@@ -1,0 +1,189 @@
+module uniFissSitesField_class
+
+  use numPrecision
+  use genericProcedures,     only : fatalError, numToChar
+  use dictionary_class,      only : dictionary
+  use particle_class,        only : particle, particleState
+  use particleDungeon_class, only : particleDungeon
+  use field_inter,           only : field
+  use vectorField_inter,     only : vectorField
+
+  ! Tally Maps
+  use tallyMap_inter,             only : tallyMap
+  use tallyMapFactory_func,       only : new_tallyMap
+
+  implicit none
+  private
+
+  !!
+  !! Public Pointer Cast
+  !!
+  public :: uniFissSitesField_TptrCast
+
+  !!
+  !! Uniform Fission Sites Field
+  !!
+  !! Returns a 2D vector with:
+  !! - fraction of fissionable material volume occupied by the required cell
+  !! - percentage of fission sites in the required cell
+  !! NOTE: as things are now, results are correct only if all the spatial bins
+  !!       include the same amount of fissionable material (are of equal size) !!!!!
+  !!
+  !! Sample Dictionary Input:
+  !!   uniformFissionSites { map { <map definition> }}
+  !!
+  !! Public Members:
+  !!   net ->  map that lays over the geometry. It should be a spatial map, an
+  !!           energy map wouldn't make much sense!
+  !!   N   ->  total number of map bins
+  !!   sourceFraction -> array with the percentage of fission sites in each bin
+  !!   buildSource    -> array used to 'tally' fission sites
+  !!
+  !! Interface:
+  !!   vectorField interface
+  !!
+  type, public, extends(vectorField) :: uniFissSitesField
+    class(tallyMap), allocatable :: net
+    integer(shortInt)            :: N = 0
+    real(defReal), dimension(:), allocatable     :: sourceFraction
+    real(defReal), dimension(:), allocatable     :: buildSource
+  contains
+    ! Superclass interface
+    procedure :: init
+    procedure :: kill
+    procedure :: at
+    procedure :: storeFS
+    procedure :: updateMap
+  end type uniFissSitesField
+
+contains
+
+  !!
+  !! Initialise from dictionary
+  !!
+  !! See field_inter for details
+  !!
+  subroutine init(self, dict)
+    class(uniFissSitesField), intent(inout) :: self
+    class(dictionary), intent(in) :: dict
+    integer(shortInt), parameter  :: ALL = 0
+    character(100), parameter     :: Here = 'init (uniFissSitesField_class.f90)'
+
+    ! Initialise overlay map
+    call new_tallyMap(self % net, dict % getDictPtr('map'))
+    self % N = self % net % bins(ALL)
+
+    allocate(self % sourceFraction(self % N), self % buildSource(self % N),self % weights(self % N))
+    self % sourceFraction = ONE/self % N
+    self % buildSource = ZERO
+
+  end subroutine init
+
+  !!
+  !! Return to uninitialised state
+  !!
+  elemental subroutine kill(self)
+    class(uniFissSitesField), intent(inout) :: self
+
+    call self % net % kill()
+    deallocate(self % net)
+    deallocate(self % sourceFraction)
+    deallocate(self % buildSource)
+
+    self % N = 0
+
+  end subroutine kill
+
+  !!
+  !! Get value of the vector field given the phase-space location of a particle
+  !!
+  !! See vectorField_inter for details
+  !!
+  function at(self, p) result(val)
+    class(uniFissSitesField), intent(in) :: self
+    class(particle), intent(inout)       :: p
+    real(defReal), dimension(3)          :: val
+    type(particleState)                  :: state
+    integer(shortInt)                    :: binIdx
+
+    ! Get current particle state
+    state = p
+
+    ! Read map bin index
+    binIdx = self % net % map(state)
+
+    ! Return if invalid bin index
+    if (binIdx == 0) then
+      val = ONE
+      return
+    end if
+
+    val(1) = ONE / self % N
+    val(2) = self % sourceFraction(binIdx)
+    val(3) = ZERO
+
+  end function at
+
+  !!
+  !! Store the fission sites generated in a vector
+  !!
+  !! Args:
+  !! state [in] -> particle state of the fission site
+  !!
+  subroutine storeFS(self, state)
+    class(uniFissSitesField), intent(inout) :: self
+    type(particleState), intent(in)         :: state
+    integer(shortInt)                       :: idx
+
+    idx = self % net % map(state)
+    if (idx == 0) return
+    ! Add fission sites where appropriate
+    self % buildSource(idx) = self % buildSource(idx) + state % wgt
+
+  end subroutine storeFS
+
+  !!
+  !! Calculates fission site probability distribution
+  !! It accounts for possible ares of the map having zero events
+  !!
+  subroutine updateMap(self)
+    class(uniFissSitesField), intent(inout) :: self
+    integer(shortInt) :: i
+
+    ! Eliminate zeros in the distribution
+    do i = 1, self % N
+      if (self % buildSource(i) == ZERO) self % buildSource(i) = ONE
+    end do
+    ! Normalise to calculate probability
+    self % sourceFraction = self % buildSource / sum(self % buildSource)
+
+    self % buildSource = ZERO
+
+  end subroutine updateMap
+
+  !!
+  !! Cast field pointer to uniFissSitesField pointer
+  !!
+  !! Args:
+  !!   source [in] -> source pointer of class field
+  !!
+  !! Result:
+  !!   Null is source is not of uniFissSitesField
+  !!   Pointer to source if source is uniFissSitesField type
+  !!
+  pure function uniFissSitesField_TptrCast(source) result(ptr)
+    class(field), pointer, intent(in) :: source
+    type(uniFissSitesField), pointer  :: ptr
+
+    select type (source)
+      type is (uniFissSitesField)
+        ptr => source
+
+      class default
+        ptr => null()
+    end select
+
+  end function uniFissSitesField_TptrCast
+
+
+end module uniFissSitesField_class

--- a/Geometry/Fields/VectorFields/uniFissSitesField_class.f90
+++ b/Geometry/Fields/VectorFields/uniFissSitesField_class.f90
@@ -73,7 +73,7 @@ contains
     call new_tallyMap(self % net, dict % getDictPtr('map'))
     self % N = self % net % bins(ALL)
 
-    allocate(self % sourceFraction(self % N), self % buildSource(self % N),self % weights(self % N))
+    allocate(self % sourceFraction(self % N), self % buildSource(self % N))
     self % sourceFraction = ONE/self % N
     self % buildSource = ZERO
 

--- a/Geometry/Fields/VectorFields/uniformVectorField_class.f90
+++ b/Geometry/Fields/VectorFields/uniformVectorField_class.f90
@@ -3,7 +3,7 @@ module uniformVectorField_class
   use numPrecision
   use genericProcedures, only : fatalError, numToChar
   use dictionary_class,  only : dictionary
-  use coord_class,       only : coordList
+  use particle_class,    only : particle
   use field_inter,       only : field
   use vectorField_inter, only : vectorField
 
@@ -77,9 +77,9 @@ contains
   !!
   !! See vectorField_inter for details
   !!
-  function at(self, coords) result(val)
+  function at(self, p) result(val)
     class(uniformVectorField), intent(in) :: self
-    type(coordList), intent(in)           :: coords
+    class(particle), intent(inout)        :: p
     real(defReal), dimension(3)           :: val
 
     val = self % val

--- a/Geometry/Fields/VectorFields/vectorField_inter.f90
+++ b/Geometry/Fields/VectorFields/vectorField_inter.f90
@@ -1,8 +1,8 @@
 module vectorField_inter
 
   use numPrecision
-  use field_inter, only : field
-  use coord_class, only : coordList
+  use field_inter,    only : field
+  use particle_class, only : particle
 
   implicit none
   private
@@ -38,10 +38,10 @@ module vectorField_inter
     !! Result:
     !!   Size 3 vector of real values.
     !!
-    function at(self, coords) result(val)
-      import :: vectorField, coordList, defReal
+    function at(self, p) result(val)
+      import :: vectorField, particle, defReal
       class(vectorField), intent(in) :: self
-      type(coordList), intent(in)    :: coords
+      class(particle), intent(inout) :: p
       real(defReal), dimension(3)    :: val
     end function at
 

--- a/Geometry/Tests/geometryReg_iTest.f90
+++ b/Geometry/Tests/geometryReg_iTest.f90
@@ -7,9 +7,10 @@ module geometryReg_iTest
   use geometry_inter,    only : geometry
   use field_inter,       only : field
   use materialMenu_mod,  only : mm_init => init, mm_kill => kill
-  use geometryReg_mod,   only : gr_addGeom => addGeom, gr_geomIdx => geomIdx, gr_geomPtr => geomPtr,&
-                                gr_addField => addField, gr_fieldIdx => fieldIdx, &
-                                gr_fieldPtr => fieldPtr, gr_kill => kill
+  use geometryReg_mod,   only : gr_geomIdx => geomIdx, gr_geomPtr => geomPtr,&
+                                gr_fieldIdx => fieldIdx, gr_fieldPtr => fieldPtr, gr_kill => kill
+  use geometryFactory_func, only : new_geometry
+  use fieldFactory_func,    only : new_field
   use pfUnit_mod
   implicit none
 
@@ -73,7 +74,7 @@ contains
     ! Build 10 instances of geometry
     do i = 1, 10
       name = 'geom'//numToChar(i)
-      call gr_addGeom(name, dict, silent=.true.)
+      call new_geometry(dict, name, silent=.true.)
     end do
 
     ! Get some indexes
@@ -111,7 +112,7 @@ contains
     ! Build 10 instances of fields
     do i = 1, 10
       name = 'field'//numToChar(i)
-      call gr_addField(name, dict)
+      call new_field(dict, name)
     end do
 
     ! Get some indexes

--- a/Geometry/fieldFactory_func.f90
+++ b/Geometry/fieldFactory_func.f90
@@ -1,0 +1,80 @@
+!!
+!! Module to build new fields. Called by geometryReg_mod
+!!
+module fieldFactory_func
+
+  use numPrecision
+  use genericProcedures, only : fatalError
+  use dictionary_class,  only : dictionary
+
+  ! Fields
+  use field_inter,              only : field
+  use uniformScalarField_class, only : uniformScalarField
+  use uniformVectorField_class, only : uniformVectorField
+  use uniFissSitesField_class,  only : uniFissSitesField
+
+  ! Geometry
+  use geometryReg_mod,          only : gr_addField => addField
+
+  implicit none
+  private
+
+
+  !! Parameters
+  character(nameLen), dimension(*), parameter :: AVAILABLE_FIELDS = ['uniformScalarField',&
+                                                                     'uniformVectorField',&
+                                                                     'uniFissSitesField ']
+
+   ! Public interface
+   public :: new_field
+
+contains
+
+  !!
+  !! Allocates and initialises field from dictionary
+  !!
+  !! Args:
+  !!   dict [in]   -> Dictionary with definition
+  !!   name [in]   -> Name of the field for the geometry registry
+  !!
+  !! Errors:
+  !!   fatalError is type of field is unknown
+  !!
+  subroutine new_field(dict, name)
+    class(dictionary), intent(in)  :: dict
+    character(nameLen), intent(in) :: name
+    class(field), allocatable      :: kentta
+    character(nameLen)             :: type
+    character(100), parameter :: Here = 'new_field (fieldFactory_func.f90) '
+
+    ! Get type
+    call dict % get(type, 'type')
+
+    ! Build Field
+    select case (type)
+      case ('uniformScalarField')
+        allocate(uniformScalarField :: kentta)
+
+      case ('uniformVectorField')
+        allocate(uniformVectorField :: kentta)
+
+      case ('uniFissSitesField')
+        allocate(uniFissSitesField :: kentta)
+
+      case default
+        print '(A)', "AVAILABLE FIELDS:"
+        print '(A)', AVAILABLE_FIELDS
+        call fatalError(Here, trim(type)//' is not valid field. See list above.')
+
+    end select
+
+    ! Initialise Field
+    call kentta % init(dict)
+
+    ! Call geometry registry to add field
+    call gr_addField(kentta, name)
+
+  end subroutine new_field
+
+
+end module fieldFactory_func

--- a/Geometry/fieldFactory_func.f90
+++ b/Geometry/fieldFactory_func.f90
@@ -1,5 +1,5 @@
 !!
-!! Module to build new fields. Called by geometryReg_mod
+!! Module to build new fields and add them to the geometry registry
 !!
 module fieldFactory_func
 
@@ -31,7 +31,8 @@ module fieldFactory_func
 contains
 
   !!
-  !! Allocates and initialises field from dictionary
+  !! Initialises field from dictionary. The field gets then allocated
+  !! inside the geometry registry
   !!
   !! Args:
   !!   dict [in]   -> Dictionary with definition

--- a/Geometry/geometryFactory_func.f90
+++ b/Geometry/geometryFactory_func.f90
@@ -1,0 +1,85 @@
+!!
+!! Module to build new fields. Called by geometryReg_mod
+!!
+module geometryFactory_func
+
+  use numPrecision
+  use genericProcedures, only : fatalError
+  use dictionary_class,  only : dictionary
+  use charMap_class,     only : charMap
+
+  ! Geometry
+  use geometry_inter,    only : geometry
+  use geometryStd_class, only : geometryStd
+  use geometryReg_mod,   only : gr_addGeom => addGeom
+
+  ! Meterial interface
+  use materialMenu_mod,  only : mm_nameMap => nameMap
+
+  implicit none
+  private
+
+
+  !! Parameters
+  character(nameLen), dimension(*), parameter :: AVAILABLE_GEOMETRIES = ['geometryStd']
+
+  ! Public interface
+  public :: new_geometry
+
+contains
+
+  !!
+  !! Allocates and initialises a geometry from dictionary
+  !!
+  !! This is Factory procedure for geometries
+  !!
+  !! Args:
+  !!   dict [in]  -> Dictionary with geometry definition
+  !!   name [in]  -> Name of the geometry for the geometry registry
+  !!   silent [in] -> Optional. Set to .true. to surpress console messeges. Default .false.
+  !!     Note that errors will still be printed with silent=.true.
+  !!
+  !! Errors:
+  !!   fatalError is type of geometry is unknown
+  !!
+  subroutine new_geometry(dict, name, silent)
+    class(dictionary), intent(in)          :: dict
+    character(nameLen), intent(in)         :: name
+    logical(defBool), optional, intent(in) :: silent
+    class(geometry), allocatable           :: geom
+    logical(defBool)                       :: silent_l
+    character(nameLen)                     :: type
+    character(100), parameter :: Here = 'new_geometry (geometryFactory_func.f90)'
+
+    ! Get silent flag
+    if (present(silent)) then
+      silent_l = silent
+    else
+      silent_l = .false.
+    end if
+
+    ! Get type
+    call dict % get(type, 'type')
+
+    ! Allocate to right type
+    select case (type)
+      case ('geometryStd')
+        allocate(geometryStd :: geom)
+
+      case default
+        print '(A)', 'AVAILABLE GEOMETRIES'
+        print '(A)', AVAILABLE_GEOMETRIES
+        call fatalError(Here, trim(type)// ' is not valid geometry. See list above.')
+
+    end select
+
+    ! Initialise geometry
+    call geom % init(dict, mm_nameMap, silent_l)
+
+    ! Call geometry registry to add geometry
+    call gr_addGeom(geom, name)
+
+  end subroutine new_geometry
+
+
+end module geometryFactory_func

--- a/Geometry/geometryFactory_func.f90
+++ b/Geometry/geometryFactory_func.f90
@@ -1,5 +1,5 @@
 !!
-!! Module to build new fields. Called by geometryReg_mod
+!! Module to build new geometries and add them to the geometry registry
 !!
 module geometryFactory_func
 
@@ -29,9 +29,8 @@ module geometryFactory_func
 contains
 
   !!
-  !! Allocates and initialises a geometry from dictionary
-  !!
-  !! This is Factory procedure for geometries
+  !! Initialises a geometry from dictionary. This is then allocated inside
+  !! the geometry registry
   !!
   !! Args:
   !!   dict [in]  -> Dictionary with geometry definition

--- a/Geometry/geometryReg_mod.f90
+++ b/Geometry/geometryReg_mod.f90
@@ -43,6 +43,7 @@ module geometryReg_mod
   use field_inter,              only : field
   use uniformScalarField_class, only : uniformScalarField
   use uniformVectorField_class, only : uniformVectorField
+  use uniFissSitesField_class,  only : uniFissSitesField
 
   implicit none
   private
@@ -77,7 +78,8 @@ module geometryReg_mod
   !! Parameters
   character(nameLen), dimension(*), parameter :: AVAILABLE_GEOMETRIES = ['geometryStd']
   character(nameLen), dimension(*), parameter :: AVAILABLE_FIELDS = ['uniformScalarField',&
-                                                                     'uniformVectorField']
+                                                                     'uniformVectorField',&
+                                                                     'uniFissSitesField ']
   integer(shortInt), parameter :: START_SIZE = 5
   real(defReal), parameter     :: GROWTH_RATE = 1.6_defReal
 
@@ -407,6 +409,9 @@ contains
 
       case ('uniformVectorField')
         allocate(uniformVectorField :: kentta)
+
+      case ('uniFissSitesField')
+        allocate(uniFissSitesField :: kentta)
 
       case default
         print '(A)', "AVAILABLE FIELDS:"

--- a/Geometry/geometryReg_mod.f90
+++ b/Geometry/geometryReg_mod.f90
@@ -122,7 +122,6 @@ contains
       silent_l = .false.
     end if
 
-
     ! Get free index
     idx = geometryNameMap % getOrDefault(name, NOT_PRESENT)
 

--- a/Geometry/geometryReg_mod.f90
+++ b/Geometry/geometryReg_mod.f90
@@ -32,18 +32,11 @@ module geometryReg_mod
   use dictionary_class,  only : dictionary
   use charMap_class,     only : charMap
 
-  ! Meterial interface
-  use materialMenu_mod,  only : mm_nameMap => nameMap
-
   ! Geometry
   use geometry_inter,    only : geometry
-  use geometryStd_class, only : geometryStd
 
   ! Fields
-  use field_inter,              only : field
-  use uniformScalarField_class, only : uniformScalarField
-  use uniformVectorField_class, only : uniformVectorField
-  use uniFissSitesField_class,  only : uniFissSitesField
+  use field_inter,       only : field
 
   implicit none
   private
@@ -75,11 +68,6 @@ module geometryReg_mod
   public :: fieldPtr
   public :: kill
 
-  !! Parameters
-  character(nameLen), dimension(*), parameter :: AVAILABLE_GEOMETRIES = ['geometryStd']
-  character(nameLen), dimension(*), parameter :: AVAILABLE_FIELDS = ['uniformScalarField',&
-                                                                     'uniformVectorField',&
-                                                                     'uniFissSitesField ']
   integer(shortInt), parameter :: START_SIZE = 5
   real(defReal), parameter     :: GROWTH_RATE = 1.6_defReal
 
@@ -108,21 +96,12 @@ contains
   !! Errors:
   !!   fatalError if geometry with the name was already defined
   !!
-  subroutine addGeom(name, dict, silent)
-    character(nameLen), intent(in)         :: name
-    class(dictionary), intent(in)          :: dict
-    logical(defBool), optional, intent(in) :: silent
-    integer(shortInt)                      :: idx
-    logical(defBool)                       :: silent_l
+  subroutine addGeom(geom, name)
+    class(geometry), allocatable, intent(inout) :: geom
+    character(nameLen), intent(in)              :: name
+    integer(shortInt)                           :: idx
     integer(shortInt), parameter :: NOT_PRESENT = -7
     character(100), parameter    :: Here = 'addGeom (geometryReg_mod.f90)'
-
-    ! Get silent value
-    if (present(silent)) then
-      silent_l = silent
-    else
-      silent_l = .false.
-    end if
 
     ! Get free index
     idx = geometryNameMap % getOrDefault(name, NOT_PRESENT)
@@ -138,7 +117,9 @@ contains
     ! Initialise & store index
     call geometryNameMap % add(name, idx)
     geometries(idx) % name = name
-    call new_geometry(geometries(idx) % geom, dict, mm_namemap, silent_l)
+
+    ! Point geometry
+    call move_alloc(geom, geometries(idx) % geom)
 
   end subroutine addGeom
 
@@ -225,10 +206,10 @@ contains
   !! Errors:
   !!   fatalError if field with the name was already defined
   !!
-  subroutine addField(name, dict)
-    character(nameLen), intent(in)         :: name
-    class(dictionary), intent(in)          :: dict
-    integer(shortInt)                      :: idx
+  subroutine addField(kentta, name)
+    class(field), allocatable, intent(inout) :: kentta
+    character(nameLen), intent(in)           :: name
+    integer(shortInt)                        :: idx
     integer(shortInt), parameter :: NOT_PRESENT = -7
     character(100), parameter    :: Here = 'addField (geometryReg_mod.f90)'
 
@@ -246,7 +227,9 @@ contains
     ! Initialise & store index
     call fieldNameMap % add(name, idx)
     fields(idx) % name = name
-    call new_field(fields(idx) % kentta, dict)
+
+    ! Point field
+    call move_alloc(kentta, fields(idx) % kentta)
 
   end subroutine addField
 
@@ -331,99 +314,6 @@ contains
     fieldTop = 0
 
   end subroutine kill
-
-  !!
-  !! Allocates and initialises a geometry from dictionary
-  !!
-  !! This is Factory procedure for geometries
-  !!
-  !! Args:
-  !!   geom [out] -> Allocatable geometry to be allocated
-  !!   dict [in]  -> Dictionary with geometry definition
-  !!   mats [in]  -> Map of material names to matIdx
-  !!   silent [in] -> Optional. Set to .true. to surpress console messeges. Default .false.
-  !!     Note that errors will still be printed with silent=.true.
-  !!
-  !! Errors:
-  !!   fatalError is type of geometry is unknown
-  !!
-  subroutine new_geometry(geom, dict, mats, silent)
-    class(geometry), allocatable, intent(out) :: geom
-    class(dictionary), intent(in)             :: dict
-    type(charMap), intent(in)                 :: mats
-    logical(defBool), optional, intent(in)    :: silent
-    logical(defBool)                          :: silent_l
-    character(nameLen)                        :: type
-    character(100), parameter :: Here = 'new_geometry (geometryReg_mod.f90)'
-
-    ! Get type
-    call dict % get(type, 'type')
-
-    ! Get silent flag
-    if (present(silent)) then
-      silent_l = silent
-    else
-      silent_l = .false.
-    end if
-
-    ! Allocate to right type
-    select case (type)
-      case ('geometryStd')
-        allocate(geometryStd :: geom)
-
-      case default
-        print '(A)', 'AVAILABLE GEOMETRIES'
-        print '(A)', AVAILABLE_GEOMETRIES
-        call fatalError(Here, trim(type)// ' is not valid geometry. See list above.')
-
-    end select
-
-    ! Initialise geometry
-    call geom % init(dict, mats, silent_l)
-
-  end subroutine new_geometry
-
-  !!
-  !! Allocates and initialises field from dictionary
-  !!
-  !! Args:
-  !!   kentta [out] -> Field to be allocated (kentta ~= field (Fi.))
-  !!   dict [in]   -> Dictionary with definition
-  !!
-  !! Errors:
-  !!   fatalError is type of field is unknown
-  !!
-  subroutine new_field(kentta, dict)
-    class(field), allocatable, intent(out) :: kentta
-    class(dictionary), intent(in)          :: dict
-    character(nameLen)                     :: type
-    character(100), parameter :: Here = 'new_field (geometryReg_mod.f90) '
-
-    ! Get type
-    call dict % get(type, 'type')
-
-    ! Build Field
-    select case (type)
-      case ('uniformScalarField')
-        allocate(uniformScalarField :: kentta)
-
-      case ('uniformVectorField')
-        allocate(uniformVectorField :: kentta)
-
-      case ('uniFissSitesField')
-        allocate(uniFissSitesField :: kentta)
-
-      case default
-        print '(A)', "AVAILABLE FIELDS:"
-        print '(A)', AVAILABLE_FIELDS
-        call fatalError(Here, trim(type)//' is not valid field. See list above.')
-
-    end select
-
-    ! Initialise Field
-    call kentta % init(dict)
-
-  end subroutine new_field
 
   !!
   !! Get geometry free Idx

--- a/Geometry/geometryReg_mod.f90
+++ b/Geometry/geometryReg_mod.f90
@@ -88,10 +88,8 @@ contains
   !! Gets information about materials from materialMenu
   !!
   !! Args:
-  !!   name [in]   -> Name of the geometry
-  !!   dict [in]   -> Dictionary with geometry definition
-  !!   silent [in] -> Optional. Set to .true. to surpress console messeges. Default .false.
-  !!     Note that errors will still be printed with silent=.true.
+  !!   geom [in] -> Pre-initialised geometry, to be allocated
+  !!   name [in] -> Name of the geometry
   !!
   !! Errors:
   !!   fatalError if geometry with the name was already defined
@@ -200,8 +198,8 @@ contains
   !! Add Field definition
   !!
   !! Args:
+  !!   kentta [in] -> Pre-initialised field, to be allocated
   !!   name [in]   -> Name of the field
-  !!   dict [in]   -> Dictionary with field definition
   !!
   !! Errors:
   !!   fatalError if field with the name was already defined

--- a/ParticleObjects/Source/fissionSource_class.f90
+++ b/ParticleObjects/Source/fissionSource_class.f90
@@ -124,7 +124,7 @@ contains
     integer(shortInt)                    :: matIdx, uniqueID, nucIdx, i, G_out
     character(100), parameter :: Here = 'sampleParticle (fissionSource_class.f90)'
 
-    ! Get pointer to approperiate nuclear database
+    ! Get pointer to appropriate nuclear database
     if (self % isMG) then
       nucData => ndReg_getNeutronMG()
     else
@@ -134,10 +134,10 @@ contains
 
     i = 0
     rejection : do
-      ! Protect against infinate loop
+      ! Protect against infinite loop
       i = i +1
       if ( i > 200) then
-        call fatalError(Here, 'Infinate loop in sampling of fission sites. Please check that&
+        call fatalError(Here, 'Infinite loop in sampling of fission sites. Please check that&
                               & defined volume contains fissile material.')
       end if
 

--- a/ParticleObjects/particleDungeon_class.f90
+++ b/ParticleObjects/particleDungeon_class.f90
@@ -64,7 +64,7 @@ module particleDungeon_class
     integer(shortInt)    :: pop = 0     ! Current population size of the dungeon
 
     ! Storage space
-    type(particleState), dimension(:), allocatable :: prisoners
+    type(particleState), dimension(:), allocatable, public :: prisoners
 
   contains
     !! Build procedures
@@ -144,17 +144,17 @@ contains
     self % pop = self % pop + 1
     pop = self % pop
     !$omp end atomic
-    
+
     ! Check for population overflow
     if (pop > size(self % prisoners)) then
       call fatalError(Here,'Run out of space for particles.&
                            & Max size:'//numToChar(size(self % prisoners)) //&
                             ' Current population: ' // numToChar(self % pop))
     end if
-    
+
     ! Load new particle
     self % prisoners(pop) = p
-    
+
   end subroutine detain_particle
 
   !!
@@ -198,16 +198,16 @@ contains
     self % pop = self % pop + 1
     pop = self % pop
     !$omp end atomic
-    
+
     ! Check for population overflow
     if (pop > size(self % prisoners)) then
       call fatalError(Here,'Run out of space for particles.&
                            & Max size:'//numToChar(size(self % prisoners)) //&
                             ' Current population: ' // numToChar(self % pop))
     end if
-   
+
     ! Load new particle
-    self % prisoners(pop) = p_state 
+    self % prisoners(pop) = p_state
 
   end subroutine detain_particleState
 
@@ -252,7 +252,7 @@ contains
     pop = self % pop
     self % pop = self % pop - 1
     !$omp end atomic
-    
+
     ! Load data into the particle
     p = self % prisoners(pop)
     p % isDead = .false.

--- a/ParticleObjects/particle_class.f90
+++ b/ParticleObjects/particle_class.f90
@@ -255,7 +255,7 @@ contains
   !!
   !! Copy phase coordinates into particle
   !!
-  subroutine particle_fromParticleState(LHS,RHS)
+  pure subroutine particle_fromParticleState(LHS,RHS)
     class(particle), intent(inout)   :: LHS
     type(particleState), intent(in)  :: RHS
 
@@ -351,7 +351,7 @@ contains
   !! Return cell index at a given nesting level n
   !!  If no n is given return for lowest nesting level
   !!
-  function getCellIdx(self,n) result(idx)
+  pure function getCellIdx(self,n) result(idx)
     class(particle), intent(in)             :: self
     integer(shortInt),optional, intent(in)  :: n
     integer(shortInt)                       :: idx
@@ -370,7 +370,7 @@ contains
   !!
   !! Return universe index at a given nesting level n
   !!
-  function getUniIdx(self,n) result(idx)
+  pure function getUniIdx(self,n) result(idx)
     class(particle), intent(in)             :: self
     integer(shortInt),optional, intent(in)  :: n
     integer(shortInt)                       :: idx
@@ -489,7 +489,7 @@ contains
   !!
   !! Resets the particle's nesting level
   !!
-  subroutine takeAboveGeom(self)
+  pure subroutine takeAboveGeom(self)
     class(particle), intent(inout) :: self
 
     call self % coords % takeAboveGeom()

--- a/PhysicsPackages/eigenPhysicsPackage_class.f90
+++ b/PhysicsPackages/eigenPhysicsPackage_class.f90
@@ -23,7 +23,7 @@ module eigenPhysicsPackage_class
   ! Geometry
   use geometry_inter,                 only : geometry
   use geometryReg_mod,                only : gr_geomPtr  => geomPtr, gr_addGeom => addGeom, &
-                                             gr_geomIdx  => geomIdx
+                                             gr_geomIdx  => geomIdx, gr_addField => addField
 
   ! Nuclear Data
   use materialMenu_mod,               only : mm_nMat           => nMat
@@ -141,7 +141,7 @@ contains
     class(tallyResult),allocatable            :: res
     type(collisionOperator), save             :: collOp
     class(transportOperator),allocatable,save :: transOp
-    type(RNG), target, save                   :: pRNG     
+    type(RNG), target, save                   :: pRNG
     type(particle), save                      :: neutron
     real(defReal)                             :: k_old, k_new
     real(defReal)                             :: elapsed_T, end_T, T_toEnd
@@ -151,10 +151,10 @@ contains
     !$omp parallel
     ! Create particle buffer
     call buffer % init(self % bufferSize)
-    
+
     ! Initialise neutron
     neutron % geomIdx = self % geomIdx
-    
+
     ! Create a collision + transport operator which can be made thread private
     collOp = self % collOp
     transOp = self % transOp
@@ -183,10 +183,10 @@ contains
         pRNG = self % pRNG
         neutron % pRNG => pRNG
         call neutron % pRNG % stride(n)
-        
-        ! Obtain particle current cycle dungeon 
+
+        ! Obtain particle current cycle dungeon
         call self % thisCycle % copy(neutron, n)
-        
+
         bufferLoop: do
           call self % geom % placeCoord(neutron % coords)
 
@@ -204,7 +204,7 @@ contains
             call collOp % collide(neutron, tally, buffer, self % nextCycle)
             if(neutron % isDead) exit history
           end do history
-        
+
           ! Clear out buffer
           if (buffer % isEmpty()) then
             exit bufferLoop
@@ -213,12 +213,12 @@ contains
           end if
 
         end do bufferLoop
-      
+
       end do gen
       !$omp end parallel do
-      
-      call self % thisCycle % cleanPop() 
-      
+
+      call self % thisCycle % cleanPop()
+
       ! Update RNG
       call self % pRNG % stride(self % pop + 1)
 
@@ -365,7 +365,7 @@ contains
     character(10)                             :: time
     character(8)                              :: date
     character(:),allocatable                  :: string
-    character(nameLen)                        :: nucData, energy, geomName
+    character(nameLen)                        :: nucData, energy, geomName, fieldName
     type(outputFile)                          :: test_out
     type(visualiser)                          :: viz
     character(100), parameter :: Here ='init (eigenPhysicsPackage_class.f90)'
@@ -436,6 +436,13 @@ contains
     call gr_addGeom(geomName, tempDict)
     self % geomIdx = gr_geomIdx(geomName)
     self % geom    => gr_geomPtr(self % geomIdx)
+
+    ! Read uniform fission site option as a geometry field
+    if (dict % isPresent('uniformFissionSites')) then
+      tempDict => dict % getDictPtr('uniformFissionSites')
+      fieldName = 'UFS'
+      call gr_addField(fieldName, tempDict)
+    end if
 
     ! Activate Nuclear Data *** All materials are active
     call ndReg_activate(self % particleType, nucData, self % geom % activeMats())

--- a/PhysicsPackages/eigenPhysicsPackage_class.f90
+++ b/PhysicsPackages/eigenPhysicsPackage_class.f90
@@ -22,11 +22,14 @@ module eigenPhysicsPackage_class
 
   ! Geometry
   use geometry_inter,                 only : geometry
-  use geometryReg_mod,                only : gr_geomPtr  => geomPtr, gr_addGeom   => addGeom, &
-                                             gr_geomIdx  => geomIdx, gr_addField  => addField, &
+  use geometryReg_mod,                only : gr_geomPtr  => geomPtr, gr_geomIdx  => geomIdx, &
                                              gr_fieldIdx => fieldIdx, gr_fieldPtr => fieldPtr
+  use geometryFactory_func,           only : new_geometry
+
+  ! Fields
   use field_inter,                    only : field
   use uniFissSitesField_class,        only : uniFissSitesField, uniFissSitesField_TptrCast
+  use fieldFactory_func,              only : new_field
 
   ! Nuclear Data
   use materialMenu_mod,               only : mm_nMat           => nMat
@@ -443,7 +446,7 @@ contains
     ! Build geometry
     tempDict => dict % getDictPtr('geometry')
     geomName = 'eigenGeom'
-    call gr_addGeom(geomName, tempDict)
+    call new_geometry(tempDict, geomName)
     self % geomIdx = gr_geomIdx(geomName)
     self % geom    => gr_geomPtr(self % geomIdx)
 
@@ -466,7 +469,7 @@ contains
       self % ufs = .true.
       ! Build and initialise
       tempDict => dict % getDictPtr('uniformFissionSites')
-      call gr_addField(nameUFS, tempDict)
+      call new_field(tempDict, nameUFS)
       ! Save UFS field
       field => gr_fieldPtr(gr_fieldIdx(nameUFS))
       self % ufsField => uniFissSitesField_TptrCast(field)

--- a/PhysicsPackages/eigenPhysicsPackage_class.f90
+++ b/PhysicsPackages/eigenPhysicsPackage_class.f90
@@ -374,7 +374,7 @@ contains
     character(10)                             :: time
     character(8)                              :: date
     character(:),allocatable                  :: string
-    character(nameLen)                        :: nucData, energy, geomName, ufsName
+    character(nameLen)                        :: nucData, energy, geomName
     type(outputFile)                          :: test_out
     type(visualiser)                          :: viz
     class(field), pointer                     :: field
@@ -464,12 +464,11 @@ contains
     ! Read uniform fission site option as a geometry field
     if (dict % isPresent('uniformFissionSites')) then
       self % ufs = .true.
-      ufsName = 'UFS'
       ! Build and initialise
       tempDict => dict % getDictPtr('uniformFissionSites')
-      call gr_addField(ufsName, tempDict)
+      call gr_addField(nameUFS, tempDict)
       ! Save UFS field
-      field => gr_fieldPtr(gr_fieldIdx(ufsName))
+      field => gr_fieldPtr(gr_fieldIdx(nameUFS))
       self % ufsField => uniFissSitesField_TptrCast(field)
       ! Initialise
       call self % ufsField % estimateVol(self % geom, self % pRNG, self % particleType)

--- a/PhysicsPackages/rayVolPhysicsPackage_class.f90
+++ b/PhysicsPackages/rayVolPhysicsPackage_class.f90
@@ -15,8 +15,9 @@ module rayVolPhysicsPackage_class
   ! Geometry
   use coord_class,                    only : coordList
   use geometry_inter,                 only : geometry, distCache
-  use geometryReg_mod,                only : gr_geomPtr  => geomPtr, gr_addGeom => addGeom, &
-                                             gr_geomIdx  => geomIdx, gr_kill    => kill
+  use geometryReg_mod,                only : gr_geomPtr  => geomPtr, gr_geomIdx  => geomIdx, &
+                                             gr_kill    => kill
+  use geometryFactory_func,           only : new_geometry
 
   ! Nuclear Data
   use materialMenu_mod,               only : mm_nMat           => nMat, mm_matName => matName
@@ -177,7 +178,7 @@ contains
     ! Build geometry
     tempDict => dict % getDictPtr('geometry')
     geomName = 'rayCalcGeom'
-    call gr_addGeom(geomName, tempDict)
+    call new_geometry(tempDict, geomName)
     self % geomIdx = gr_geomIdx(geomName)
     self % geom    => gr_geomPtr(self % geomIdx)
 

--- a/PhysicsPackages/vizPhysicsPackage_class.f90
+++ b/PhysicsPackages/vizPhysicsPackage_class.f90
@@ -14,8 +14,8 @@ module vizPhysicsPackage_class
 
   ! Geometry
   use geometry_inter,                 only : geometry
-  use geometryReg_mod,                only : gr_geomPtr  => geomPtr, gr_addGeom => addGeom, &
-                                             gr_geomIdx  => geomIdx
+  use geometryReg_mod,                only : gr_geomPtr  => geomPtr, gr_geomIdx  => geomIdx
+  use geometryFactory_func,           only : new_geometry
 
   ! Nuclear Data
   use materialMenu_mod,               only : mm_nMat           => nMat
@@ -83,7 +83,7 @@ contains
     ! Build geometry
     tempDict => dict % getDictPtr('geometry')
     geomName = 'visualGeom'
-    call gr_addGeom(geomName, tempDict)
+    call new_geometry(tempDict, geomName)
     self % geomIdx = gr_geomIdx(geomName)
     self % geom    => gr_geomPtr(self % geomIdx)
 

--- a/SharedModules/universalVariables.f90
+++ b/SharedModules/universalVariables.f90
@@ -28,7 +28,7 @@ module universalVariables
   integer(shortINt), parameter, public :: COLL_EV = 1, &
                                           BOUNDARY_EV = 2, &
                                           CROSS_EV = 3, &
-                                          LOST_EV  = 4 
+                                          LOST_EV  = 4
 
   ! Create definitions for readability when dealing with positions relative to surfaces
   logical(defBool), parameter, public :: behind = .FALSE., &
@@ -76,5 +76,8 @@ module universalVariables
 
   ! Unit conversion
   real(defReal), parameter :: joulesPerMeV = 1.60218e-13     ! Convert MeV to J
+
+  ! Global name variables used to define specific geometry or field types
+  character(nameLen), parameter :: nameUFS = 'uniFissSites'
 
 end module universalVariables

--- a/Tallies/TallyMaps/CMakeLists.txt
+++ b/Tallies/TallyMaps/CMakeLists.txt
@@ -13,6 +13,7 @@ add_sources(./tallyMap_inter.f90
             ./weightMap_class.f90
             ./sphericalMap_class.f90
             ./cellMap_class.f90
+            ./cylindricalMap_class.f90
  #          ./matXsMap_class.f90
             )
 

--- a/Tallies/TallyMaps/CMakeLists.txt
+++ b/Tallies/TallyMaps/CMakeLists.txt
@@ -25,4 +25,5 @@ add_unit_tests(./Tests/materialMap_test.f90
                ./Tests/multiMap_test.f90
                ./Tests/homogMatMap_test.f90
                ./Tests/sphericalMap_test.f90
-               ./Tests/cellMap_test.f90)
+               ./Tests/cellMap_test.f90
+               ./Tests/cylindricalMap_test.f90)

--- a/Tallies/TallyMaps/Tests/cellMap_test.f90
+++ b/Tallies/TallyMaps/Tests/cellMap_test.f90
@@ -8,8 +8,9 @@ module cellMap_test
   use charMap_class,      only : charMap
   use outputFile_class,   only : outputFile
   use cellMap_class,      only : cellMap
-  use geometryReg_mod,    only : gr_addGeom => addGeom, gr_kill => kill
-  use materialMenu_mod,   only : mm_nameMap => nameMap
+  use geometryReg_mod,    only : gr_kill => kill
+  use geometryFactory_func, only : new_geometry
+  use materialMenu_mod,     only : mm_nameMap => nameMap
 
   implicit none
 
@@ -80,7 +81,7 @@ contains
     call mm_nameMap % add(name, VOID_MAT)
 
     ! Initialise geometry in geomReg
-    call gr_addGeom('geom', dict, .true.)
+    call new_geometry(dict, 'geom', silent = .true.)
 
     ! Initialise dictionaries
     call mapDict1 % init(2)

--- a/Tallies/TallyMaps/Tests/cylindricalMap_test.f90
+++ b/Tallies/TallyMaps/Tests/cylindricalMap_test.f90
@@ -1,0 +1,206 @@
+module cylindricalMap_test
+  use numPrecision
+  use pFUnit_mod
+  use particle_class,          only : particleState
+  use dictionary_class,        only : dictionary
+  use outputFile_class,        only : outputFile
+
+  use cylindricalMap_class,    only : cylindricalMap
+
+  implicit none
+
+
+@testCase
+  type, extends(TestCase) :: test_cylindricalMap
+    private
+    type(cylindricalMap) :: map_radial
+    type(cylindricalMap) :: map_unstruct
+    type(cylindricalMap) :: map_3d
+
+  contains
+    procedure :: setUp
+    procedure :: tearDown
+  end type test_cylindricalMap
+
+contains
+
+  !!
+  !! Sets up test_cylindricalMap object we can use in a number of tests
+  !!
+  subroutine setUp(this)
+    class(test_cylindricalMap), intent(inout) :: this
+    type(dictionary)                          :: tempDict
+
+    ! Build radial map with different orientation & minimum radius
+    call tempDict % init(5)
+    call tempDict % store('orientation','x')
+    call tempDict % store('rGrid','equivolume')
+    call tempDict % store('Rmin', 2.0_defReal)
+    call tempDict % store('Rmax', 10.0_defReal)
+    call tempDict % store('rN', 5)
+
+    call this % map_radial % init(tempDict)
+    call tempDict % kill()
+
+    ! Build map with different origin & unstruct bins
+    call tempDict % init(3)
+    call tempDict % store('origin',[ONE, ONE])
+    call tempDict % store('rGrid','unstruct')
+    call tempDict % store('bins', [1.5_defReal, 2.3_defReal, 3.8_defReal, 8.0_defReal])
+
+    call this % map_unstruct % init(tempDict)
+    call tempDict % kill()
+
+    ! Build map with radial, axial and azimuthal bins
+    call tempDict % init(8)
+    call tempDict % store('rGrid','lin')
+    call tempDict % store('Rmax', 20.0_defReal)
+    call tempDict % store('rN', 10)
+    call tempDict % store('axGrid','lin')
+    call tempDict % store('axN', 4)
+    call tempDict % store('axMin', 2.0_defReal)
+    call tempDict % store('axMax', 8.0_defReal)
+    call tempDict % store('azimuthalN', 4)
+
+    call this % map_3d % init(tempDict)
+    call tempDict % kill()
+
+  end subroutine setUp
+
+  !!
+  !! Kills test_cylindricalMap object we can use in a number of tests
+  !!
+  subroutine tearDown(this)
+    class(test_cylindricalMap), intent(inout) :: this
+
+    call this % map_radial % kill()
+    call this % map_unstruct % kill()
+    call this % map_3d % kill()
+
+  end subroutine tearDown
+
+!!<><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+!! PROPER TESTS BEGIN HERE
+!!<><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+
+  !!
+  !! Test radial map with different orientation & minimum radius
+  !!
+@Test
+  subroutine testRadial(this)
+    class(test_cylindricalMap), intent(inout) :: this
+    real(defReal),dimension(4),parameter      :: r = [0.4_defReal, 5.38_defReal, 8.9_defReal, 9.1_defReal]
+    real(defReal), dimension(4),parameter     :: phi = [1.4_defReal, 3.0_defReal, 0.5_defReal, PI/2]
+    real(defReal), dimension(4),parameter     :: z = [1.0_defReal, 39.8_defReal, 0.05_defReal, -12.2_defReal]
+    integer(shortInt),dimension(4),parameter  :: RES_IDX = [0, 2, 4, 5]
+    integer(shortInt),dimension(4)            :: idx
+    type(particleState),dimension(4)          :: states
+
+    ! Initialise states
+    states(:) % r(1) = z
+    states(:) % r(2) = r * cos(phi)
+    states(:) % r(3) = r * sin(phi)
+
+    idx = this % map_radial % map(states)
+
+    @assertEqual(RES_IDX, idx)
+
+  end subroutine testRadial
+
+  !!
+  !! Test map with different origin & unstruct bins
+  !!
+@Test
+  subroutine testUnstruct(this)
+    class(test_cylindricalMap), intent(inout) :: this
+    real(defReal),dimension(4),parameter      :: r = [1.52_defReal, 5.5_defReal, 8.9_defReal, 2.88_defReal]
+    real(defReal), dimension(4),parameter     :: phi = [1.4_defReal, 3.0_defReal, 0.5_defReal, PI/2]
+    real(defReal), dimension(4), parameter    :: z = [1.0_defReal, 39.8_defReal, 0.05_defReal, -12.2_defReal]
+    integer(shortInt),dimension(4),parameter  :: RES_IDX = [1, 3, 0, 2]
+    integer(shortInt),dimension(4)            :: idx
+    type(particleState),dimension(4)          :: states
+
+    ! Initialise states
+    states(:) % r(1) = r * cos(phi)
+    states(:) % r(2) = r * sin(phi)
+    states(:) % r(3) = z
+
+    ! Shift the origin
+    states(:) % r(1) = states(:) % r(1) + ONE
+    states(:) % r(2) = states(:) % r(2) + ONE
+    states(:) % r(3) = states(:) % r(3)
+
+    idx = this % map_unstruct % map(states)
+    @assertEqual(RES_IDX, idx)
+
+  end subroutine testUnstruct
+
+  !!
+  !! Test map with different origin & unstruct bins
+  !!
+@Test
+  subroutine test3d(this)
+    class(test_cylindricalMap), intent(inout) :: this
+    real(defReal),dimension(4),parameter      :: r = [1.52_defReal, 5.5_defReal, 18.9_defReal, 12.88_defReal]
+    real(defReal), dimension(4),parameter     :: phi = [1.4_defReal, 3.0_defReal, 0.5_defReal, -3.14_defReal]
+    real(defReal), dimension(4), parameter    :: z = [6.7_defReal, 2.8_defReal, 1.1_defReal, 3.9_defReal]
+    integer(shortInt),dimension(4),parameter  :: RES_IDX = [111, 123, 0, 17]
+    integer(shortInt),dimension(4)            :: idx
+    type(particleState),dimension(4)          :: states
+
+    ! Initialise states
+    states(:) % r(1) = r * cos(phi)
+    states(:) % r(2) = r * sin(phi)
+    states(:) % r(3) = z
+
+    idx = this % map_3d % map(states)
+    @assertEqual(RES_IDX, idx)
+
+  end subroutine test3d
+
+  !!
+  !! Test bin number retrival
+  !!
+@Test
+  subroutine testBinNumber(this)
+    class(test_cylindricalMap), intent(inout) :: this
+
+    @assertEqual(10, this % map_3d % bins(1),'1st Dimension')
+    @assertEqual(160, this % map_3d % bins(0),'All bins')
+    @assertEqual(4,  this % map_3d % bins(3),'3rd Dimension')
+    @assertEqual(4,  this % map_3d % bins(2),'2nd Dimension')
+    @assertEqual(1,  this % map_radial % bins(2),'2nd Dimension')
+    @assertEqual(0,  this % map_3d % bins(4),'Invalid Dimension')
+
+    ! Get dimensionality
+    @assertEqual(3, this % map_unstruct % dimensions())
+
+  end subroutine testBinNumber
+
+  !!
+  !! Test correctness of print subroutine
+  !! Does not checks that values are correct, but that calls sequance is without errors
+  !!
+@Test
+  subroutine testPrint(this)
+    class(test_cylindricalMap), intent(inout) :: this
+    type(outputFile)                          :: out
+
+    call out % init('dummyPrinter', fatalErrors = .false.)
+
+    call this % map_radial % print(out)
+    @assertTrue(out % isValid(),'Radial map case')
+    call out % reset()
+
+    call this % map_unstruct % print(out)
+    @assertTrue(out % isValid(),'Unstruct map case')
+    call out % reset()
+
+    call this % map_3d % print(out)
+    @assertTrue(out % isValid(),'3d map case')
+    call out % reset()
+
+  end subroutine testPrint
+
+
+end module cylindricalMap_test

--- a/Tallies/TallyMaps/Tests/sphericalMap_test.f90
+++ b/Tallies/TallyMaps/Tests/sphericalMap_test.f90
@@ -13,8 +13,10 @@ module sphericalMap_test
 @testCase
   type, extends(TestCase) :: test_sphericalMap
     private
-    type(sphericalMap) :: map_from_zero
-    type(sphericalMap) :: map_from_min
+    type(sphericalMap) :: map_lin_from_zero
+    type(sphericalMap) :: map_lin_from_min
+    type(sphericalMap) :: map_unstruct
+    type(sphericalMap) :: map_equivol
 
   contains
     procedure :: setUp
@@ -36,7 +38,7 @@ contains
     call tempDict % store('Rmax', 10.0_defReal)
     call tempDict % store('N', 20)
 
-    call this % map_from_zero % init(tempDict)
+    call this % map_lin_from_zero % init(tempDict)
     call tempDict % kill()
 
     ! Build map with diffrent origin & minimum radius
@@ -47,7 +49,25 @@ contains
     call tempDict % store('Rmax', 10.0_defReal)
     call tempDict % store('N', 5)
 
-    call this % map_from_min % init(tempDict)
+    call this % map_lin_from_min % init(tempDict)
+    call tempDict % kill()
+
+    ! Build map with unstruct bins
+    call tempDict % init(2)
+    call tempDict % store('grid', 'unstruct')
+    call tempDict % store('bins', [4.0_defReal, 5.8_defReal, 7.3_defReal, 10.5_defReal, 15.0_defReal])
+
+    call this % map_unstruct % init(tempDict)
+    call tempDict % kill()
+
+    ! Build map with equivolume bins
+    call tempDict % init(4)
+    call tempDict % store('grid', 'equivolume')
+    call tempDict % store('Rmin', 2.0_defReal)
+    call tempDict % store('Rmax', 20.0_defReal)
+    call tempDict % store('N', 8)
+
+    call this % map_equivol % init(tempDict)
     call tempDict % kill()
 
   end subroutine setUp
@@ -58,8 +78,10 @@ contains
   subroutine tearDown(this)
     class(test_sphericalMap), intent(inout) :: this
 
-    call this % map_from_zero % kill()
-    call this % map_from_min % kill()
+    call this % map_lin_from_zero % kill()
+    call this % map_lin_from_min % kill()
+    call this % map_unstruct % kill()
+    call this % map_equivol % kill()
 
   end subroutine tearDown
 
@@ -85,7 +107,7 @@ contains
     states(:) % r(2) = r * sin(phi) * sin(tht)
     states(:) % r(3) = r * cos(tht)
 
-    idx = this % map_from_zero % map(states)
+    idx = this % map_lin_from_zero % map(states)
     @assertEqual(RES_IDX, idx)
 
   end subroutine testFromOrigin
@@ -113,10 +135,56 @@ contains
     states(:) % r(2) = states(:) % r(2) + ONE
     states(:) % r(3) = states(:) % r(3) + ONE
 
-    idx = this % map_from_min % map(states)
+    idx = this % map_lin_from_min % map(states)
     @assertEqual(RES_IDX, idx)
 
   end subroutine testFromMin
+
+  !!
+  !! Test grid with unstruct bins
+  !!
+@Test
+  subroutine testUnstruct(this)
+    class(test_sphericalMap), intent(inout) :: this
+    real(defReal),dimension(4),parameter     :: r = [4.5_defReal, 15.5_defReal, 8.9_defReal, 11.0_defReal]
+    real(defReal), dimension(4),parameter    :: phi = [1.4_defReal, 3.98_defReal, 0.5_defReal, PI/2]
+    real(defReal), dimension(4), parameter   :: tht = [ZERO, PI/2, PI/4, -PI/2]
+    integer(shortInt),dimension(4),parameter :: RES_IDX = [1, 0, 3, 4]
+    integer(shortInt),dimension(4)           :: idx
+    type(particleState),dimension(4)         :: states
+
+    ! Initialise states
+    states(:) % r(1) = r * cos(phi) * sin(tht)
+    states(:) % r(2) = r * sin(phi) * sin(tht)
+    states(:) % r(3) = r * cos(tht)
+
+    idx = this % map_unstruct % map(states)
+    @assertEqual(RES_IDX, idx)
+
+  end subroutine testUnstruct
+
+  !!
+  !! Test grid with equivolume bins
+  !!
+@Test
+  subroutine testEquiVol(this)
+    class(test_sphericalMap), intent(inout) :: this
+    real(defReal),dimension(4),parameter     :: r = [1.5_defReal, 5.5_defReal, 18.9_defReal, 11.0_defReal]
+    real(defReal), dimension(4),parameter    :: phi = [1.4_defReal, 3.98_defReal, 0.5_defReal, PI/2]
+    real(defReal), dimension(4), parameter   :: tht = [ZERO, PI/2, PI/4, -PI/2]
+    integer(shortInt),dimension(4),parameter :: RES_IDX = [0, 1, 7, 2]
+    integer(shortInt),dimension(4)           :: idx
+    type(particleState),dimension(4)         :: states
+
+    ! Initialise states
+    states(:) % r(1) = r * cos(phi) * sin(tht)
+    states(:) % r(2) = r * sin(phi) * sin(tht)
+    states(:) % r(3) = r * cos(tht)
+
+    idx = this % map_equivol % map(states)
+    @assertEqual(RES_IDX, idx)
+
+  end subroutine testEquiVol
 
   !!
   !! Test bin number retrival
@@ -125,12 +193,13 @@ contains
   subroutine testBinNumber(this)
     class(test_sphericalMap), intent(inout) :: this
 
-    @assertEqual(20, this % map_from_zero % bins(1),'1st Dimension')
-    @assertEqual(20, this % map_from_zero % bins(0),'All bins')
-    @assertEqual(0,  this % map_from_zero % bins(-3),'Invalid Dimension')
+    @assertEqual(20, this % map_lin_from_zero % bins(1),'1st Dimension')
+    @assertEqual(4,  this % map_unstruct % bins(1),'1st Dimension')
+    @assertEqual(20, this % map_lin_from_zero % bins(0),'All bins')
+    @assertEqual(0,  this % map_lin_from_zero % bins(-3),'Invalid Dimension')
 
     ! Get dimensionality
-    @assertEqual(1, this % map_from_zero % dimensions())
+    @assertEqual(1, this % map_lin_from_zero % dimensions())
 
   end subroutine testBinNumber
 
@@ -145,12 +214,20 @@ contains
 
     call out % init('dummyPrinter', fatalErrors = .false.)
 
-    call this % map_from_zero % print(out)
+    call this % map_lin_from_zero % print(out)
     @assertTrue(out % isValid(),'Default-initialised map case')
     call out % reset()
 
-    call this % map_from_min % print(out)
+    call this % map_lin_from_min % print(out)
     @assertTrue(out % isValid(),'Map with minimum R')
+    call out % reset()
+
+    call this % map_unstruct % print(out)
+    @assertTrue(out % isValid(),'Map with unstruct bins')
+    call out % reset()
+
+    call this % map_equivol % print(out)
+    @assertTrue(out % isValid(),'Map with equivolume bins')
     call out % reset()
 
   end subroutine testPrint

--- a/Tallies/TallyMaps/cylindricalMap_class.f90
+++ b/Tallies/TallyMaps/cylindricalMap_class.f90
@@ -30,15 +30,17 @@ module cylindricalMap_class
   !! Sample Dictionary Input:
   !!  cylindricalMap {
   !!    type cylindricalMap;
-  !!    #origin (1.0 0.0);# // Optional. Default (0 0)
+  !!    #orientation x;# // Optional. Defeult z
+  !!    #origin (1.0 0.0);# // Optional. Default (0 0). Order is xy, xz or yz.
   !!    rGrid lin;
   !!    #Rmin 2.0;#  // Optional. Default 0.0
   !!    Rmax  10.0;
   !!    rN 10;
-  !!    #zGrid lin; // Optional
-  !!    Zmin 2.0;
-  !!    Zmax  10.0;
-  !!    zN 10;
+  !!    #axGrid lin; // Optional
+  !!    #axMin 2.0;   // Needed if axGrid is present
+  !!    #axMax  10.0; // Needed if axGrid is present
+  !!    #axN 10;      // Needed if axGrid is present
+  !!    #azimuthalBins 4;# // Optional
   !!    }
   !!
   !!
@@ -46,9 +48,14 @@ module cylindricalMap_class
     private
     real(defReal), dimension(2) :: origin = ZERO
     type(grid)                  :: rBounds
-    type(grid)                  :: zBounds
+    type(grid)                  :: axBounds
+    type(grid)                  :: azBounds
     integer(shortInt)           :: rN = 0
-    integer(shortInt)           :: zN = 0
+    integer(shortInt)           :: axN = 0
+    integer(shortInt)           :: azN = 0
+    integer(shortInt)           :: DIM1
+    integer(shortInt)           :: DIM2
+    integer(shortInt)           :: DIM3
   contains
     ! Superclass
     procedure :: init
@@ -72,7 +79,7 @@ contains
     class(dictionary), intent(in)            :: dict
     real(defReal), dimension(:), allocatable :: temp, grid
     character(nameLen)                       :: type
-    real(defReal)                            :: Rmin, Rmax, Zmin, Zmax, vol
+    real(defReal)                            :: Rmin, Rmax, Amin, Amax, vol
     integer(shortInt)                        :: i
     character(100), parameter :: Here = 'init (sphericalmap_class.f90)'
 
@@ -84,15 +91,38 @@ contains
     end if
     self % origin = temp
 
+    ! Check orientation of the cylinder
+    if (dict % isPresent('orientation')) then
+      select case(type)
+        case('x')
+          self % DIM1 = 2
+          self % DIM2 = 3
+          self % DIM3 = 1
+        case('y')
+          self % DIM1 = 1
+          self % DIM2 = 3
+          self % DIM3 = 2
+        case('z')
+          self % DIM1 = 1
+          self % DIM2 = 2
+          self % DIM3 = 3
+      end select
+    else
+      self % DIM1 = 1
+      self % DIM2 = 2
+      self % DIM3 = 3
+    end if
+
     ! Load radial grid information
     if (.not.dict % isPresent('rGrid')) call fatalError(Here, 'Keyword rGrid must be present')
     call dict % get(type, 'rGrid')
 
+    ! Check type of radial grid bins
     select case(type)
       case('lin')
         call dict % getOrDefault(Rmin, 'Rmin', ZERO)
         call dict % get(Rmax, 'Rmax')
-        call dict % get(self % rN, 'N')
+        call dict % get(self % rN, 'rN')
 
         ! Check that minimum radius is OK
         if (Rmin < ZERO) then
@@ -114,7 +144,7 @@ contains
 
         call dict % getOrDefault(Rmin, 'Rmin', ZERO)
         call dict % get(Rmax, 'Rmax')
-        call dict % get(self % rN, 'N')
+        call dict % get(self % rN, 'rN')
 
         ! Check that minimum radius is OK
         if (Rmin < ZERO) then
@@ -139,24 +169,30 @@ contains
     end select
 
     ! Load axial grid information
-    if (dict % isPresent('zGrid')) then
+    if (dict % isPresent('axGrid')) then
 
-      call dict % get(type, 'zGrid')
+      call dict % get(type, 'axGrid')
 
       select case(type)
         case('lin')
-          call dict % get(Zmin, 'Zmin')
-          call dict % get(Zmax, 'Zmax')
-          call dict % get(self % zN, 'N')
+          call dict % get(Amin, 'axMin')
+          call dict % get(Amax, 'axMax')
+          call dict % get(self % axN, 'axN')
 
           ! Build grid
-          call self % zBounds % init(Zmin, Zmax, self % zN, type)
+          call self % axBounds % init(Amin, Amax, self % axN, type)
 
         case default
-          call fatalError(Here, "'zGrid' can take only values of: lin")
+          call fatalError(Here, "'axGrid' can take only values of: lin")
 
         end select
 
+      end if
+
+      ! Load azimuthal grid information
+      if (dict % isPresent('azimuthalBins')) then
+        call dict % get(self % azN, 'azimuthalBins')
+        call self % azBounds % init(-PI, PI, self % azN, 'lin')
       end if
 
   end subroutine init
@@ -173,7 +209,8 @@ contains
 
     if (D == 1 .or. D == 0) then
       N = self % rN
-      if (self % zN /= 0) N = N * self % zN
+      if (self % axN /= 0) N = N * self % axN
+      if (self % azN /= 0) N = N * self % azN
     else
       N = 0
     end if
@@ -199,8 +236,8 @@ contains
   !! See tallyMap for specification
   !!
   function getAxisName(self) result(name)
-    class(cylindricalMap), intent(in) :: self
-    character(nameLen)          :: name
+    class(cylindricalMap), intent(in)  :: self
+    character(nameLen)                 :: name
 
     name ='cylindricalMap'
 
@@ -214,31 +251,46 @@ contains
   elemental function map(self, state) result(idx)
     class(cylindricalMap), intent(in) :: self
     class(particleState), intent(in)  :: state
-    integer(shortInt)                 :: idx, zIdx
-    real(defReal)                     :: r
+    integer(shortInt)                 :: idx, aIdx, N
+    real(defReal)                     :: r, x, y, theta
 
     ! Calculate the distance from the origin
-    r = norm2(state % r(1:2) - self % origin)
+    r = norm2(state % r([self % DIM1, self % DIM2]) - self % origin)
 
     ! Search and return 0 if r is out-of-bounds
     idx = self % rBounds % search(r)
+    N = self % rN
 
     if (idx == valueOutsideArray) then
       idx = 0
       return
     end if
 
-    ! Return if there is no axial dimension
-    if (self % zN == 0) return
-
-    ! Search along the axial dimension
-    zIdx = self % zBounds % search(state % r(3))
-    if (zIdx == valueOutsideArray) then
-      idx = 0
-      return
+    ! Update if there is axial dimension
+    if (self % axN /= 0) then
+      ! Search along the axial dimension and return 0 if index is out-of-bounds
+      aIdx = self % axBounds % search(state % r(self % DIM3))
+      if (aIdx == valueOutsideArray) then
+        idx = 0
+        return
+      end if
+      ! Compute new index and update number of bins
+      idx = N * (aIdx - 1) + idx
+      N = N * self % axN
     end if
 
-    idx = self % rN * (zIdx - 1) + idx
+    ! Update if there is azimuthal dimension
+    if (self % azN /= 0) then
+
+      x = state % r(self % DIM1) - self % origin(1)
+      y = state % r(self % DIM2) - self % origin(2)
+
+      theta = atan2(y,x)
+      ! Search along the azimuthal dimension and return 0 if index is out-of-bounds
+      aIdx = self % azBounds % search(theta)
+      ! Compute new index and update number of bins
+      idx = N * (aIdx - 1) + idx
+    end if
 
   end function map
 
@@ -254,7 +306,7 @@ contains
     integer(shortInt)                :: i
 
     ! Name the array
-    name = trim(self % getAxisName()) //'radialBounds'
+    name = trim(self % getAxisName()) //'RadialBounds'
 
     call out % startArray(name, [2,self % rN])
     do i = 1, self % rN
@@ -268,16 +320,32 @@ contains
     call out % endArray()
 
     ! Add axial dimension if present
-    if (self % zN /= 0) then
-      name = trim(self % getAxisName()) //'axialBounds'
+    if (self % axN /= 0) then
+      name = trim(self % getAxisName()) //'AxialBounds'
 
-      call out % startArray(name, [2,self % zN])
-      do i = 1, self % zN
+      call out % startArray(name, [2,self % axN])
+      do i = 1, self % axN
         ! Print lower bin boundary
-        call out % addValue(self % zBounds % bin(i))
+        call out % addValue(self % axBounds % bin(i))
 
         ! Print upper bin boundar
-        call out % addValue(self % zBounds % bin(i + 1))
+        call out % addValue(self % axBounds % bin(i + 1))
+
+      end do
+      call out % endArray()
+    end if
+
+    ! Add azimuthal dimension if present
+    if (self % azN /= 0) then
+      name = trim(self % getAxisName()) //'AzimuthalBounds'
+
+      call out % startArray(name, [2,self % azN])
+      do i = 1, self % azN
+        ! Print lower bin boundary
+        call out % addValue(self % azBounds % bin(i) + PI)
+
+        ! Print upper bin boundar
+        call out % addValue(self % azBounds % bin(i + 1) + PI)
 
       end do
       call out % endArray()
@@ -295,9 +363,11 @@ contains
 
     self % origin = ZERO
     call self % rBounds % kill()
-    call self % zBounds % kill()
+    call self % axBounds % kill()
+    call self % azBounds % kill()
     self % rN = 0
-    self % zN = 0
+    self % axN = 0
+    self % azN = 0
 
   end subroutine kill
 

--- a/Tallies/TallyMaps/sphericalMap_class.f90
+++ b/Tallies/TallyMaps/sphericalMap_class.f90
@@ -120,7 +120,8 @@ contains
         allocate(grid(self % N + 1))
         ! Calculate grid boundaries
         grid(1) = Rmin
-        do i = 2,size(grid)
+        grid(self % N + 1) = Rmax
+        do i = 2,self % N
           grid(i) = (vol + grid(i-1)**3)**(ONE/3.0_defReal)
         end do
 

--- a/Tallies/TallyMaps/sphericalMap_class.f90
+++ b/Tallies/TallyMaps/sphericalMap_class.f90
@@ -128,7 +128,7 @@ contains
         call self % rBounds % init(grid)
 
       case default
-        call fatalError(Here, "'grid' can take only values of: lin")
+        call fatalError(Here, "'grid' can take only values of: lin, unstruct and equivolume")
 
     end select
 

--- a/Tallies/TallyMaps/tallyMapFactory_func.f90
+++ b/Tallies/TallyMaps/tallyMapFactory_func.f90
@@ -21,6 +21,7 @@ module tallyMapFactory_func
   ! TallyMap implementations
   use multiMap_class,         only : multiMap
   use sphericalMap_class,     only : sphericalMap
+  use cylindricalMap_class,   only : cylindricalMap
 
   implicit none
   private
@@ -33,8 +34,9 @@ module tallyMapFactory_func
   ! It is printed if type was unrecognised
   ! NOTE:
   ! For now  it is necessary to adjust trailing blanks so all enteries have the same length
-  character(nameLen),dimension(*),parameter :: AVALIBLE_tallyMaps = [ 'multiMap    ', &
-                                                                      'sphericalMap']
+  character(nameLen),dimension(*),parameter :: AVALIBLE_tallyMaps = [ 'multiMap      ', &
+                                                                      'sphericalMap  ', &
+                                                                      'cylindricalMap']
 
 
 contains
@@ -75,6 +77,10 @@ contains
 
         case('sphericalMap')
           allocate( sphericalMap :: new)
+          call new % init(dict)
+
+        case('cylindricalMap')
+          allocate( cylindricalMap :: new)
           call new % init(dict)
 
       end select


### PR DESCRIPTION
This pull request includes a few changes. 

First, I am adding UFS as a vector field. This requires the specification of a spatial map over some fissile material. The input information are read inside the eigenPP; additionally, a UFS flag must be specified in the implicit collision operator for this to work. 

This spatial/material map does not have to be homogeneous in terms of fissile material volume; if it isn't, one should specify it in the input with a 'uniformMap 0' flag. In this case, a simple routine to estimate the fissile material volume of each bin in the map is run during initialisation. 

Then, when generating fission neutrons in collOpImp, the map is read and updated. 

Additional features in this pull request are: 
- adding unstruct and equivolume bins in the tally sphericalMap
- generating a 3D cylindrical tally map, i.e. with radial, axial and azimuthal bins
