### PR TITLE
Fix uninitialised flag in json printer

### DIFF
--- a/UserInterface/fileOutput/asciiJSON_class.f90
+++ b/UserInterface/fileOutput/asciiJSON_class.f90
@@ -43,7 +43,7 @@ module asciiJSON_class
     integer(shortInt) :: ind_lvl = 0
 
     integer(shortInt), dimension(:), allocatable :: shapeBuffer
-    logical(defBool)                             :: in_array
+    logical(defBool)                             :: in_array = .false.
     integer(shortInt)                            :: count = 0
 
 


### PR DESCRIPTION
A missing initialisation have been causing segmentation error when using JSON output format. It was revealed with gfortran 12 (#26) . For earlier compilers it must have worked due to luck I think. 