### PR TITLE
Enable message folding in fatalError

### DIFF
--- a/SharedModules/CMakeLists.txt
+++ b/SharedModules/CMakeLists.txt
@@ -12,7 +12,8 @@ add_sources( ./genericProcedures.f90
              ./statisticalTests_func.f90
              ./timer_mod.f90
              ./charLib_func.f90
-             ./openmp_func.f90)
+             ./openmp_func.f90
+             ./errors_mod.f90)
 
 add_unit_tests( ./Tests/grid_test.f90
                 ./Tests/energyGrid_test.f90

--- a/SharedModules/errors_mod.f90
+++ b/SharedModules/errors_mod.f90
@@ -1,0 +1,71 @@
+!!
+!! Collection of functions to handle errors and warnings
+!!
+!! It declared as a singleton-like module with a state since it will contain
+!! a warning log at a later date.
+!!
+module errors_mod
+  use iso_fortran_env, only : error_unit
+
+  use numPrecision
+  use universalVariables, only : MAX_COL
+
+  implicit none
+
+contains
+
+  !!
+  !! Kill the execution and print the error message
+  !!
+  !! A pretty(ish) formatted error is printed to STDOUT. A backtrace should
+  !! be produced as well (at least with gfortran but may be different for
+  !! other compilers)
+  !!
+  !! Args:
+  !!   where [in] -> Location of the error
+  !!   why [in] -> Error message
+  !!
+  !! Note:
+  !!   Error message will be broken at MAX_COL column. Breaking can happen
+  !!   mid-word.
+  !!
+  subroutine fatalError(where, why)
+    character(*), intent(in) :: where
+    character(*), intent(in) :: why
+    integer(shortInt)        :: end, start
+
+    ! Upper frame
+    write(error_unit, *) repeat('<>', MAX_COL / 2)
+
+    write(error_unit, *) 'Fatal has occurred in:'
+    write(error_unit, *) where, new_line('')
+    write(error_unit, *) 'Because:'
+
+    ! Do simple message folding
+    ! Break on a whitespace if possible
+    ! Does not recognise TABS, and other whitespace characters
+    start = 1
+    do while (start < len(why))
+      end = min(start + MAX_COL, len(why))
+
+      if (end < len(why)) then ! A line break is required
+        end = start + scan(why(start: end), " ", back = .true.) - 1
+
+        ! Should not happen often but be safe in case a string with no whitespace
+        if (end <= start) end = min(start + MAX_COL, len(why))
+      end if
+
+      write(error_unit, '( " ",A)') why(start: end)
+      start = end + 1
+    end do
+
+    ! Lower frame
+    write(error_unit, *) repeat('<>', MAX_COL / 2)
+
+    ! Terminate with backtrace
+    error stop
+
+  end subroutine fatalError
+
+
+end module errors_mod

--- a/SharedModules/genericProcedures.f90
+++ b/SharedModules/genericProcedures.f90
@@ -4,6 +4,7 @@ module genericProcedures
 
   use numPrecision
   use openmp_func, only : ompGetMaxThreads
+  use errors_mod, only: fatalError
   use endfConstants
   use universalVariables
 
@@ -282,31 +283,6 @@ module genericProcedures
       end select
     end if
   end subroutine searchError
-
-  !!
-  !! Displays error message and stops execution
-  !!
-  subroutine fatalError(Where,Why)
-    character(*), intent(in)    :: Why, Where
-    character(100)              :: Line, locWhy, locWhere
-    character(20)               :: format
-
-    Line = repeat('<>',50)
-    format = '(A100)'
-    locWhere = adjustR(where)
-    locWhy = adjustR(why)
-
-    print format, Line
-    print format, 'Fatal Error has occured in:'
-    print format, locWhere
-    print *
-    print format, 'For the following reason:'
-    print format, locWhy
-    print *
-    print format, Line
-    stop
-
-  end subroutine fatalError
 
   !!
   !! Open "File" for reading under with "unitNum" reference


### PR DESCRIPTION
Changes the `fatalError` subroutine to something presentable. Resolves #33 
 - error messages will be printed to STDERR. 
 - the error message will be folded to respect `MAX_COL` parameter.  
 - uses `error stop` which will produce backtrace on some compilers 
 
 For example, a long error message will look as follows: 
 ```
 <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Fatal has occurred in:
 bestfunction (worstfile.f90)

 Because:
 This is a very long error message which will contain some number of
 detail a person may find interesting and useful for debugging.
 Although I have no clue how to build such long strings in a nice way
 in Fortran. But sometimes it may be immpossible
 sinceeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee long strings do happen.
                                                           Also a lot
 of whitespace will look weird
 <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
ERROR STOP

Error termination. Backtrace:
#0  0x7f093ce2cbd0 in ???
#1  0x7f093ce2d685 in ???
#2  0x7f093ce2e9f3 in ???
#3  0x55ad47fd29dd in __errors_mod_MOD_fatalerror
	at /home/<user_path>/SCONE/SharedModules/errors_mod.f90:57
#4  0x55ad47fcb94e in scone
	at /home/<user_path>/SCONE/Apps/scone.f90:24
#5  0x55ad47fcb7be in main
	at /home/<user_path>/SCONE/Apps/scone.f90:3

 ```
 
 In the anticipation of the warning log the function was also moved to a new `errors_mod` module.  