### PR TITLE
Add diffrent compilers to CI workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,31 +9,11 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-20.04
+    container:
+      image: mikolajkowalski/scone-test:gfortran10
     steps:
       - uses: actions/checkout@v3
-      # We need to use older Python due to PfUnit 3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.6'
-
-      - name: FetchPfUnit
-        uses: actions/checkout@v3
-        with:
-          repository: Goddard-Fortran-Ecosystem/pFUnit
-          ref: 3.3.3
-          path: ./external_pfunit
-      - name: InstallPfUnit
-        working-directory: ${{github.workspace}}/external_pfunit
-        env:
-          F90: gfortran
-          F90_VENDOR: GNU
-        run: |
-          make tests -j
-          make install INSTALL_DIR=./
-
       - name: CompileAndTest
-        env:
-          PFUNIT_INSTALL: ${{github.workspace}}/external_pfunit
         run : |
           mkdir build
           cd build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,9 +8,12 @@ on:
 
 jobs:
   build-and-test:
+    strategy:
+      matrix:
+        compiler: [gfortran8, gfortran9, gfortran10]
     runs-on: ubuntu-20.04
     container:
-      image: mikolajkowalski/scone-test:gfortran10
+      image: mikolajkowalski/scone-test:${{matrix.compiler}}
     steps:
       - uses: actions/checkout@v3
       - name: CompileAndTest


### PR DESCRIPTION
Addresses Issue #42. 

It switches the build strategy to use [Docker containers](https://hub.docker.com/r/mikolajkowalski/scone-test) which are build and published using a GitHub Actions workflow from another repository. I set it up as private for now, but perhaps it may be good idea to make it open. 

I checked that new build-and-test workflow runs fine on my fork, so I do not expect any issues on main. 

GFortran 11 and 12 is not tested because it is not trivial to get a Linux system that has it as a package, while the Python version is old enough to run with pFUnit in version 3.3.3. This makes #10 more and more paramount... 