### PR TITLE
Stream output files instead of writing them in-memory first 

### DIFF
--- a/PhysicsPackages/eigenPhysicsPackage_class.f90
+++ b/PhysicsPackages/eigenPhysicsPackage_class.f90
@@ -323,7 +323,7 @@ contains
     type(outputFile)                          :: out
     character(nameLen)                        :: name
 
-    call out % init(self % outputFormat)
+    call out % init(self % outputFormat, filename=self % outputFile)
 
     name = 'seed'
     call out % printValue(self % pRNG % getSeed(),name)
@@ -358,8 +358,6 @@ contains
     call out % startBlock(name)
     call self % activeTally % print(out)
     call out % endBlock()
-
-    call out % writeToFile(self % outputFile)
 
   end subroutine collectResults
 

--- a/PhysicsPackages/fixedSourcePhysicsPackage_class.f90
+++ b/PhysicsPackages/fixedSourcePhysicsPackage_class.f90
@@ -266,7 +266,7 @@ contains
     type(outputFile)                                :: out
     character(nameLen)                              :: name
 
-    call out % init(self % outputFormat)
+    call out % init(self % outputFormat, filename=self % outputFile)
 
     name = 'seed'
     call out % printValue(self % pRNG % getSeed(),name)
@@ -286,8 +286,6 @@ contains
 
     ! Print tally
     call self % tally % print(out)
-
-    call out % writeToFile(self % outputFile)
 
   end subroutine collectResults
 

--- a/UserInterface/fileOutput/CMakeLists.txt
+++ b/UserInterface/fileOutput/CMakeLists.txt
@@ -4,6 +4,7 @@ add_sources( ./outputFile_class.f90
              ./asciiOutputFactory_func.f90
              ./asciiMATLAB_class.f90
              ./asciiJSON_class.f90
-             ./dummyPrinter_class.f90)
+             ./dummyPrinter_class.f90
+             ./delayedStream_class.f90)
 
 add_unit_tests (./Tests/outputFile_test.f90)

--- a/UserInterface/fileOutput/asciiJSON_class.f90
+++ b/UserInterface/fileOutput/asciiJSON_class.f90
@@ -96,7 +96,7 @@ contains
   end subroutine endFile
 
   !!
-  !! Return approperiate extension for the file
+  !! Return appropriate extension for the file
   !!
   !! See asciiOutput_inter for details
   !!

--- a/UserInterface/fileOutput/asciiJSON_class.f90
+++ b/UserInterface/fileOutput/asciiJSON_class.f90
@@ -21,7 +21,7 @@ module asciiJSON_class
   !! There is indentation for each block and entry, but long multi-dimensional (N-D) arrays
   !! are printed on a single line. Also N-D arrays are represented as a JSON array of arrays.
   !!
-  !! JSON output is fairly standard so it can be easlily read into Python and other enviroments
+  !! JSON output is fairly standard so it can be easily read into Python and other environments
   !!
   !! TODO:
   !!  Currently there is a dirty fix to remove commas at the end of a block, which requires to
@@ -39,7 +39,6 @@ module asciiJSON_class
   !!
   type, public, extends(asciiOutput) :: asciiJSON
     private
-    type(charTape)    :: output
     integer(shortInt) :: ind_lvl = 0
 
     integer(shortInt), dimension(:), allocatable :: shapeBuffer
@@ -49,8 +48,8 @@ module asciiJSON_class
 
   contains
     procedure :: init
+    procedure :: endFile
     procedure :: extension
-    procedure :: writeToFile
 
     procedure :: startBlock
     procedure :: endBlock
@@ -71,10 +70,30 @@ contains
     class(asciiJSON), intent(inout) :: self
 
     ! Add the initial bracket
-    call self % output % append( "{" // NEWLINE)
+    call self % append( "{" // NEWLINE)
     self % ind_lvl = 1
 
   end subroutine init
+
+  !!
+  !! Finalise the printer
+  !!
+  !! See asciiOutput_inter for details
+  !!
+  subroutine endFile(self)
+    class(asciiJSON), intent(inout) :: self
+
+    ! Dirty fix
+    ! Remove comma from the last entry by rewind
+    ! Need to check that the character is a comma to avoid removing { when there is an empty block
+    ! TODO: Find better way. Will clash with any proper stream output
+    if (self % peek(2) == ",") then
+      call self % cut(2)
+      call self % append(NEWLINE)
+    end if
+    call self % append("}" // NEWLINE)
+
+  end subroutine endFile
 
   !!
   !! Return approperiate extension for the file
@@ -90,34 +109,6 @@ contains
   end function extension
 
   !!
-  !! Print the output to the given unit
-  !!
-  !! See asciiOutput_inter for details
-  !!
-  subroutine writeToFile(self, unit)
-    class(asciiJSON), intent(inout) :: self
-    integer(shortInt), intent(in)   :: unit
-    character(:),allocatable        :: form
-
-    ! Dirty fix
-    ! Remove comma from the last entry by rewind
-    ! Need to check that the character is a comma to avoid removing { when there is an empty block
-    ! TODO: Find better way. Will clash with any proper stream output
-    if (self % output % get(self % output % length() - 1) == ",") then
-      call self % output % cut(2)
-      call self % output % append(NEWLINE)
-    end if
-
-    ! Close the file
-    call self % output % append("}")
-
-    form = '(A' // numToChar(self % output % length()) // ')'
-
-    write(unit,form) self % output % expose()
-
-  end subroutine writeToFile
-
-  !!
   !! Change state to writing new block with "name"
   !!
   !! See asciiOutput_inter for details
@@ -127,10 +118,10 @@ contains
     character(nameLen), intent(in)  :: name
 
     ! Write indentation
-    call self % output % append(repeat(BLANK, self % ind_lvl * IND_SIZE))
+    call self % append(repeat(BLANK, self % ind_lvl * IND_SIZE))
 
     ! Open new block and increase indentation
-    call self % output % append(QUOTE // trim(name) // QUOTE // ":" // "{" // NEWLINE)
+    call self % append(QUOTE // trim(name) // QUOTE // ":" // "{" // NEWLINE)
     self % ind_lvl = self % ind_lvl + 1
 
   end subroutine startBlock
@@ -147,17 +138,17 @@ contains
     ! Remove comma from the last entry by rewind
     ! Need to check that the character is a comma to avoid removing { when there is an empty block
     ! TODO: Find better way. Will clash with any proper stream output
-    if (self % output % get(self % output % length() - 1) == ",") then
-      call self % output % cut(2)
-      call self % output % append(NEWLINE)
+    if (self % peek(2)  == ",") then
+      call self % cut(2)
+      call self % append(NEWLINE)
     end if
 
     ! Decrease and write indentation
     self % ind_lvl = self % ind_lvl - 1
-    call self % output % append(repeat(BLANK, self % ind_lvl * IND_SIZE))
+    call self % append(repeat(BLANK, self % ind_lvl * IND_SIZE))
 
     ! Close the block
-    call self % output % append("}" // ","// NEWLINE)
+    call self % append("}" // ","// NEWLINE)
 
   end subroutine endBlock
 
@@ -171,10 +162,10 @@ contains
     character(*), intent(in)        :: name
 
     ! Print indentation
-    call self % output % append(repeat(BLANK, self % ind_lvl * IND_SIZE))
+    call self % append(repeat(BLANK, self % ind_lvl * IND_SIZE))
 
     ! Write the name
-    call self % output % append(QUOTE // trim(name) // QUOTE // ":")
+    call self % append(QUOTE // trim(name) // QUOTE // ":")
 
   end subroutine startEntry
 
@@ -188,7 +179,7 @@ contains
 
     ! End with NEWLINE
     ! Comma will be written together with a number/char
-    call self % output % append(NEWLINE)
+    call self % append(NEWLINE)
 
   end subroutine endEntry
 
@@ -235,12 +226,12 @@ contains
       mul = 1
       do i = 1, size(self % shapeBuffer)
         mul = mul * self % shapeBuffer(i)
-        if (modulo(self % count, mul) == 0) call self % output % append("[")
+        if (modulo(self % count, mul) == 0) call self % append("[")
       end do
     end if
 
     ! Print the number
-    call self % output % append(val)
+    call self % append(val)
 
     if (self % in_array) then
       ! Append the count
@@ -250,12 +241,12 @@ contains
       mul = 1
       do i = 1, size(self % shapeBuffer)
         mul = mul * self % shapeBuffer(i)
-        if (modulo(self % count, mul) == 0) call self % output % append("]")
+        if (modulo(self % count, mul) == 0) call self % append("]")
       end do
     end if
 
     ! Finish entry with a comma
-    call self % output % append(",")
+    call self % append(",")
 
   end subroutine printNum
 
@@ -274,12 +265,12 @@ contains
       mul = 1
       do i = 1, size(self % shapeBuffer)
         mul = mul * self % shapeBuffer(i)
-        if (modulo(self % count, mul) == 0) call self % output % append("[")
+        if (modulo(self % count, mul) == 0) call self % append("[")
       end do
     end if
 
     ! Print the character
-    call self % output % append(QUOTE // val // QUOTE)
+    call self % append(QUOTE // val // QUOTE)
 
     if (self % in_array) then
       ! Append the count
@@ -289,12 +280,12 @@ contains
       mul = 1
       do i = 1, size(self % shapeBuffer)
         mul = mul * self % shapeBuffer(i)
-        if (modulo(self % count, mul) == 0) call self % output % append("]")
+        if (modulo(self % count, mul) == 0) call self % append("]")
       end do
     end if
 
     ! Finish entry with a comma
-    call self % output % append(",")
+    call self % append(",")
 
   end subroutine printChar
 

--- a/UserInterface/fileOutput/asciiMATLAB_class.f90
+++ b/UserInterface/fileOutput/asciiMATLAB_class.f90
@@ -99,7 +99,7 @@ contains
   end subroutine endFile
 
   !!
-  !! Return approperiate extension for the file
+  !! Return appropriate extension for the file
   !!
   !! See asciiOutput_inter for details
   !!

--- a/UserInterface/fileOutput/asciiMATLAB_class.f90
+++ b/UserInterface/fileOutput/asciiMATLAB_class.f90
@@ -23,8 +23,8 @@ module asciiMATLAB_class
   !!
   !! Printer for ASCII MATLAB output file
   !!
-  !! Creates a computer-readable matalab ".m" file.
-  !! Despite beeing in ASCII it is not intended for human-readability:
+  !! Creates a computer-readable matlab ".m" file.
+  !! Despite being in ASCII it is not intended for human-readability:
   !!  -> Each entry is a single line.
   !!  -> Furthermore every array is printed as RANK 1 array and a reshape function.
   !!
@@ -40,7 +40,7 @@ module asciiMATLAB_class
   !!   blockLevel     -> Current block level
   !!   output         -> Character that contain the output
   !!   prefix         -> Current prefix for the block
-  !!   shapeBuffer    -> Buffored shape of the current array
+  !!   shapeBuffer    -> Buffered shape of the current array
   !!
   !! Interface:
   !!   asciiOutput Interface
@@ -52,17 +52,14 @@ module asciiMATLAB_class
     type(stackChar)   :: blockNameStack
     integer(shortInt) :: blockLevel = 0
 
-    ! Outputfile
-    type(charTape) :: output
-
     ! Buffers
     type(charTape) :: prefix
     integer(shortInt), dimension(:), allocatable :: shapeBuffer
 
   contains
     procedure :: init
+    procedure :: endFile
     procedure :: extension
-    procedure :: writeToFile
 
     procedure :: startBlock
     procedure :: endBlock
@@ -90,6 +87,18 @@ contains
   end subroutine init
 
   !!
+  !! Finalise the printer
+  !!
+  !! See asciiOutput_inter for details
+  !!
+  subroutine endFile(self)
+    class(asciiMATLAB), intent(inout) :: self
+
+    ! Nothing to do
+
+  end subroutine endFile
+
+  !!
   !! Return approperiate extension for the file
   !!
   !! See asciiOutput_inter for details
@@ -103,22 +112,6 @@ contains
   end function extension
 
   !!
-  !! Print the output to the given unit
-  !!
-  !! See asciiOutput_inter for details
-  !!
-  subroutine writeToFile(self, unit)
-    class(asciiMATLAB), intent(inout) :: self
-    integer(shortInt), intent(in)     :: unit
-    character(:),allocatable          :: form
-
-    form = '(A' // numToChar(self % output % length()) // ')'
-
-    write(unit,form) self % output % expose()
-
-  end subroutine writeToFile
-
-  !!
   !! Change state to writing new block with "name"
   !!
   !! See asciiOutput_inter for details
@@ -127,11 +120,6 @@ contains
     class(asciiMATLAB), intent(inout) :: self
     character(nameLen), intent(in)    :: name
     character(100), parameter :: Here ='startBlock (asciiMATLAB_class.f90)'
-
-    ! Check if state support acction
-    ! if (self % state == IN_ENTRY .or. self % state == IN_ARRAY) then
-    !   call fatalError(Here,'Cannot start writing new block inside entry or array')
-    ! end if
 
     ! Update state - change current prefix
     call self % blockNameStack % push(name)
@@ -150,15 +138,6 @@ contains
     character(nameLen)                :: temp
     integer(shortInt)                 :: N
     character(100), parameter :: Here ='endBlock (asciiMATLAB_class.f90)'
-
-    ! Check if state support acction
-    ! if (self % state == IN_ENTRY .or. self % state == IN_ARRAY) then
-    !   call fatalError(Here,'Cannot end writing new block inside entry or array')
-    ! end if
-    !
-    ! if ( self % blockLevel == 0) then
-    !   call fatalError(Here,'Cannot exit from root block')
-    ! end if
 
     ! Update state - change current prefix
     call self % blockNameStack % pop(temp)
@@ -180,17 +159,12 @@ contains
     character(*), intent(in)          :: name
     character(100), parameter :: Here ='startEntry (asciiMATLAB_class.f90)'
 
-    ! Check if state support acction
-    ! if (self % state == IN_ENTRY .or. self % state == IN_ARRAY) then
-    !   call fatalError(Here,'Cannot star writing new entry inside entry or array')
-    ! end if
-
     ! Update state
     self % state = IN_ENTRY
 
     ! Write variable name with prefix
-    call self % output % append( trim(self % prefix % expose()) // trim(name))
-    call self % output % append( ' = ')
+    call self % append( trim(self % prefix % expose()) // trim(name))
+    call self % append( ' = ')
 
 
   end subroutine startEntry
@@ -204,16 +178,11 @@ contains
     class(asciiMATLAB), intent(inout) :: self
     character(100), parameter :: Here ='endEntry (asciiMATLAB_class.f90)'
 
-    ! Check if state support acction
-    ! if (self % state == IN_BLOCK .or. self % state == IN_ARRAY) then
-    !   call fatalError(Here,'Cannot finish entry in block or array')
-    ! end if
-
     ! Update state
     self % state = IN_BLOCK
 
     ! Write semicolon and newline
-    call self % output % append( ';' // NEWLINE)
+    call self % append( ';' // NEWLINE)
 
   end subroutine endEntry
 
@@ -227,11 +196,6 @@ contains
     integer(shortInt),dimension(:),intent(in) :: shape
     character(100), parameter :: Here ='startArray (asciiMATLAB_class.f90)'
 
-    ! Check if state support acction
-    ! if (self % state /= IN_ENTRY) then
-    !   call fatalError(Here,'Cannot finish entry in block or array')
-    ! end if
-
     ! Update state
     self % state = IN_ARRAY
 
@@ -240,10 +204,10 @@ contains
 
     ! Write start of array
     if( size(self % shapeBuffer) == 1) then
-      call self % output % append('[ ')
+      call self % append('[ ')
 
     else
-      call self % output % append('reshape([ ')
+      call self % append('reshape([ ')
 
     end if
 
@@ -259,24 +223,19 @@ contains
     integer(shortInt)                 :: i
     character(100), parameter :: Here ='endArray (asciiMATLAB_class.f90)'
 
-    ! Check if state support acction
-    ! if (self % state /= IN_ARRAY) then
-    !   call fatalError(Here,'Cannot finish array inside an entry')
-    ! end if
-
     ! Update state
     self % state = IN_ENTRY
 
     ! Write end of array
-    call self % output % cut(1)
-    call self % output % append(']')
+    call self % cut(1)
+    call self % append(']')
 
     ! Finish reshape function for higher rank arrays
     if( size(self % shapeBuffer) > 1) then
       do i=1,size(self % shapeBuffer)
-        call self % output % append(',' // numToChar(self % shapeBuffer(i)))
+        call self % append(',' // numToChar(self % shapeBuffer(i)))
       end do
-      call self % output % append(')')
+      call self % append(')')
     end if
 
   end subroutine endArray
@@ -292,13 +251,11 @@ contains
     character(100), parameter :: Here ='printNum (asciiMATLAB_class.f90)'
 
     if(self % state == IN_ARRAY) then
-      call self % output % append(val//',')
+      call self % append(val//',')
 
     else if( self % state == IN_ENTRY) then
-      call self % output % append(val)
+      call self % append(val)
 
-    ! else
-    !   call fatalError(Here,'Cannot print number directly into block')
     end if
 
   end subroutine printNum
@@ -314,13 +271,11 @@ contains
     character(100), parameter :: Here ='printChar (asciiMATLAB_class.f90)'
 
     if(self % state == IN_ARRAY) then
-      call self % output % append(BRAKET_L // APOS // val // APOS // BRAKET_R // ",")
+      call self % append(BRAKET_L // APOS // val // APOS // BRAKET_R // ",")
 
     else if( self % state == IN_ENTRY) then
-      call self % output % append(BRAKET_L // APOS // val // APOS // BRAKET_R )
+      call self % append(BRAKET_L // APOS // val // APOS // BRAKET_R )
 
-    ! else
-    !   call fatalError(Here,'Cannot print number directly into block')
     end if
 
   end subroutine printChar

--- a/UserInterface/fileOutput/asciiOutput_inter.f90
+++ b/UserInterface/fileOutput/asciiOutput_inter.f90
@@ -1,6 +1,7 @@
 module asciiOutput_inter
 
   use numPrecision
+  use delayedStream_class, only : delayedStream
 
   implicit none
   private
@@ -10,7 +11,7 @@ module asciiOutput_inter
   !!
   !! Allows stream-like output to multiple formats (e.g. MATLAB, CSV, JSON)
   !!
-  !! They recive the sequence of calls from the `outputFile` and conver them to the output file.
+  !! They receive the sequence of calls from the `outputFile` and convert them to the output file.
   !!
   !! Printers do no error checking. It is responsibility of the `outputFile` to ensure that
   !! the sequence is correct.
@@ -21,7 +22,7 @@ module asciiOutput_inter
   !!
   !! Interface:
   !!   init        -> Initialise
-  !!   extension   -> Return file extension approperiate for the format
+  !!   extension   -> Return file extension appropriate for the format
   !!   writeToFile -> Print the output to the provided unit
   !!   startBlock  -> Start new block
   !!   endBlock    -> End a block
@@ -32,10 +33,16 @@ module asciiOutput_inter
   !!
   type, public,abstract :: asciiOutput
     private
+    type(delayedStream) :: stream
   contains
+    procedure                       :: append
+    procedure                       :: cut
+    procedure                       :: peek
+    procedure                       :: close
+    procedure                       :: setUnit
     procedure(init), deferred       :: init
+    procedure(init), deferred       :: endFile
     procedure(extension), deferred  :: extension
-    procedure(writeToFile),deferred :: writeToFile
     procedure(startBlock),deferred  :: startBlock
     procedure(endBlock),deferred    :: endBlock
     procedure(startEntry),deferred  :: startEntry
@@ -61,7 +68,21 @@ module asciiOutput_inter
     end subroutine init
 
     !!
-    !! Return approperiate extension for the file
+    !! End the file
+    !!
+    !! Format may require to print some characters at the end, so the printer
+    !! needs to be notified that no more data will be provided.
+    !!
+    !! Args:
+    !!  None
+    !!
+    subroutine endFile(self)
+      import :: asciiOutput
+      class(asciiOutput), intent(inout) :: self
+    end subroutine endFile
+
+    !!
+    !! Return appropriate extension for the file
     !!
     !! Must be without any "." Thus "exe" instead of ".exe"!
     !!
@@ -73,19 +94,6 @@ module asciiOutput_inter
       class(asciiOutput), intent(in) :: self
       character(:), allocatable      :: str
     end function extension
-
-    !!
-    !! Print the output to the given unit
-    !!
-    !! Args:
-    !!  unit [in] -> Unit number of the output
-    !!
-    subroutine writeToFile(self, unit)
-      import :: asciiOutput, &
-                shortInt
-      class(asciiOutput), intent(inout) :: self
-      integer(shortInt), intent(in)     :: unit
-    end subroutine writeToFile
 
     !!
     !! Change state to writing new block with "name"
@@ -111,7 +119,7 @@ module asciiOutput_inter
     !!
     !! Change state to writing a new entry
     !!
-    !! Can recive single value or array next
+    !! Can receive single value or array next
     !!
     !! Args:
     !!   name [in] -> name of the entry
@@ -134,7 +142,7 @@ module asciiOutput_inter
     !!
     !! Start writing array with the given shape
     !!
-    !! Name should alrady be provided by "startEntry"
+    !! Name should already be provided by "startEntry"
     !!
     !! Args:
     !!   shape [in] -> Shape of the array (in column-major order)
@@ -182,5 +190,78 @@ module asciiOutput_inter
       character(*),intent(in)           :: val
     end subroutine printChar
   end interface
+
+contains
+
+
+    !!
+    !! Write data to the output
+    !!
+    !! Args:
+    !!  text [in] -> Text to be written
+    !!
+    subroutine append(self, text)
+      class(asciiOutput), intent(inout) :: self
+      character(*), intent(in)          :: text
+
+      call self % stream % write(text)
+
+    end subroutine append
+
+    !!
+    !! Remove n characters from the output
+    !!
+    !! Args:
+    !!  n [in] -> Number of characters to be removed
+    !!
+    subroutine cut(self, n)
+      class(asciiOutput), intent(inout) :: self
+      integer, intent(in)               :: n
+
+      call self % stream % cut(n)
+
+    end subroutine cut
+
+    !!
+    !! Get the nth last character from the output
+    !!
+    !! Args:
+    !!   n [in] -> How many characters back to peak
+    !!
+    function peek(self, n) result(c)
+      class(asciiOutput), intent(inout) :: self
+      integer, intent(in)               :: n
+      character(1)                      :: c
+
+      c = self % stream % peek(n)
+
+    end function peek
+
+    !!
+    !! Close the stream
+    !!
+    !! Signals to the output that no more data will be provided, so the
+    !! closing characters can be printed. In addition flushes remaining characters
+    !! in the buffer to the output.
+    !!
+    subroutine close(self)
+      class(asciiOutput), intent(inout) :: self
+
+      call self % endFile()
+      call self % stream % close()
+
+    end subroutine close
+
+    !!
+    !! Set the unit to write to
+    !!
+    subroutine setUnit(self, unit)
+      class(asciiOutput), intent(inout) :: self
+      integer(shortInt), intent(in)     :: unit
+
+      call self % stream % setUnit(unit)
+
+    end subroutine setUnit
+
 
 end module asciiOutput_inter

--- a/UserInterface/fileOutput/delayedStream_class.f90
+++ b/UserInterface/fileOutput/delayedStream_class.f90
@@ -1,0 +1,185 @@
+module delayedStream_class
+
+  use numPrecision
+  use errors_mod, only : fatalError
+
+  implicit none
+  private
+
+  integer(shortInt), parameter :: MAX_DELAY = 1024
+  integer(shortInt), parameter :: MIN_DELAY = 16
+
+  !!
+  !! Writes characters to a file with a delay to allow for backtracking.
+  !!
+  !! It is required to make writing of output format in stream-like fashion
+  !! easier to implement. For example, in JSON, it allows to backtrack and
+  !! remove trailing comma when closing a JSON dictionary.
+  !!
+  !! NOTE: We need to be careful to check if the file is open before writing
+  !!       to it. Otherwise, we will get an error.
+  !!
+  !! Private Member:
+  !!   unit      -> Unit to which the output file is connected
+  !!   bufferPos -> Position in the buffer
+  !!   buffer    -> Buffer of characters
+  !!
+  !! Interface:
+  !!   write -> Write some characters to the buffer/file
+  !!   cut   -> Remove last N characters from the buffer
+  !!   peek  -> Inspect the Nth last character in the buffer
+  !!   close -> Write all characters remaining in the buffer to the file
+  !!   setUnit -> Set the unit to which the output file is connected
+  !!
+  type, public :: delayedStream
+    private
+    integer(shortInt) :: unit = -8
+    integer(shortInt) :: bufferPos = 0
+    character(MAX_DELAY) :: buffer
+  contains
+    procedure :: write
+    procedure :: cut
+    procedure :: peek
+    procedure :: close
+    procedure :: setUnit
+
+    procedure, private :: flush
+  end type delayedStream
+
+contains
+
+  !!
+  !! Write to a delayed stream
+  !!
+  !! Args:
+  !!   text [in] -> text to write
+  !!
+  subroutine write(self, text)
+    class(delayedStream), intent(inout) :: self
+    character(*), intent(in) :: text
+    integer(shortInt) :: i
+
+    ! Write to buffer
+    do i = 1, len(text)
+      self % bufferPos = self % bufferPos + 1
+      self % buffer(self % bufferPos:self % bufferPos) = text(i:i)
+      if (self % bufferPos == MAX_DELAY) then
+        call flush(self)
+      end if
+    end do
+
+  end subroutine write
+
+  !!
+  !! Remove last characters from a delayed stream
+  !!
+  !! Args:
+  !!  n [in] -> number of characters to remove. Must be less than the MIN_DELAY.
+  !!            If n is larger than the number of characters in buffer, everything is removed.
+  !!
+  subroutine cut(self, n)
+    class(delayedStream), intent(inout) :: self
+    integer(shortInt), intent(in) :: n
+    character(100), parameter :: HERE = "cut (delayedStream_class.f90)"
+
+    if (n > MIN_DELAY) then
+      call fatalError(HERE, "n must be less than MIN_DELAY")
+    end if
+
+    self % bufferPos = max(0, self % bufferPos - n)
+
+  end subroutine cut
+
+  !!
+  !! Inspect the nth last character in the buffer
+  !!
+  !! Args:
+  !!  n [in] -> The number of characters to peek back.
+  !!
+  function peek(self, n) result(c)
+    class(delayedStream), intent(inout) :: self
+    integer(shortInt), intent(in) :: n
+    character(n) :: c
+    character(100), parameter :: HERE = "peek (delayedStream_class.f90)"
+
+    if (n > self % bufferPos) then
+      call fatalError(HERE, "n is larger than the buffer")
+    else
+      c = self % buffer(self % bufferPos - n + 1: self % bufferPos - n + 1)
+    end if
+
+  end function peek
+
+  !!
+  !! Flush contents of the buffer
+  !!
+  subroutine flush(self)
+    class(delayedStream), intent(inout) :: self
+    integer(shortInt) :: to_file
+    logical(defBool) :: isOpen
+
+    ! Do not write anything if the file is not opened
+    inquire(unit=self % unit, opened=isOpen)
+    if (.not. isOpen) then
+      return
+    end if
+
+    ! Do nothing if the buffer is below minimum length
+    if (self % bufferPos <= MIN_DELAY) then
+      return
+    end if
+    to_file = self % bufferPos - MIN_DELAY
+
+    ! Write to file only if it is open
+    if (isOpen) then
+      write(self % unit, "(A)", advance="no") self % buffer(1 : to_file)
+    end if
+
+    self % buffer(1:MIN_DELAY) = self % buffer(to_file + 1 : self % bufferPos)
+
+    self % bufferPos = MIN_DELAY
+
+  end subroutine flush
+
+  !!
+  !! Close the delayed stream
+  !!
+  subroutine close(self)
+    class(delayedStream), intent(inout) :: self
+    logical(defBool) :: isOpen
+
+    ! Do not write anything if the file is not opened
+    inquire(unit=self % unit, opened=isOpen)
+    if (.not. isOpen) then
+      return
+    end if
+
+    ! Does nothing if empty
+    if (self % bufferPos == 0) then
+      return
+    end if
+
+    ! Write the remaining buffer
+    ! Write to file only if it is open
+    if (isOpen) then
+      write(self % unit, "(A)", advance="no") self % buffer(1:self % bufferPos)
+    end if
+    self % bufferPos = 0
+
+  end subroutine close
+
+  !!
+  !! Set the unit to which the output file is connected
+  !!
+  !! Args:
+  !!  unit [in] -> Unit to which the output file is connected. May be opened or not.
+  !!               Both are fine. If it is not opened, nothing will be written to it.
+  subroutine setUnit(self, unit)
+    class(delayedStream), intent(inout) :: self
+    integer(shortInt), intent(in) :: unit
+
+    self % unit = unit
+
+  end subroutine setUnit
+
+end module delayedStream_class

--- a/UserInterface/fileOutput/dummyPrinter_class.f90
+++ b/UserInterface/fileOutput/dummyPrinter_class.f90
@@ -23,6 +23,7 @@ module dummyPrinter_class
 
   contains
     procedure :: init
+    procedure :: endFile
     procedure :: extension
 
     procedure :: startBlock
@@ -49,6 +50,18 @@ contains
     ! Nothing to do
 
   end subroutine init
+
+  !!
+  !! End the file
+  !!
+  !! See asciiOutput_inter for details
+  !!
+  subroutine endFile(self)
+    class(dummyPrinter), intent(inout) :: self
+
+    ! Nothing to do
+
+  end subroutine endFile
 
   !!
   !! Return approperiate extension for the file

--- a/UserInterface/fileOutput/dummyPrinter_class.f90
+++ b/UserInterface/fileOutput/dummyPrinter_class.f90
@@ -24,7 +24,6 @@ module dummyPrinter_class
   contains
     procedure :: init
     procedure :: extension
-    procedure :: writeToFile
 
     procedure :: startBlock
     procedure :: endBlock
@@ -63,18 +62,6 @@ contains
     str = ''
 
   end function extension
-
-  !!
-  !! Print the output to the given unit
-  !!
-  !! See asciiOutput_inter for details
-  !!
-  subroutine writeToFile(self, unit)
-    class(dummyPrinter), intent(inout) :: self
-    integer(shortInt), intent(in)      :: unit
-
-
-  end subroutine writeToFile
 
   !!
   !! Change state to writing new block with "name"

--- a/docs/Output.rst
+++ b/docs/Output.rst
@@ -38,8 +38,9 @@ Writing to an output file in SCONE is done through a series of calls to appropri
   character(nameLen) :: name
   type(outputFile)   :: out
 
-  !! Initialise output by choosing the format
-  call out % init('asciiMatlab')
+  !! Initialise output by choosing the format and output file
+  !! If no file name is provided, the output will not be printed
+  call out % init('asciiMatlab', filename="./path/to/output/without_any_extension")
 
   !! Write an integer of 7
   name = 'int'
@@ -76,9 +77,10 @@ Writing to an output file in SCONE is done through a series of calls to appropri
   !! Same goes for blocks
   call out % endBlock()
 
-  !! When done, we can write output to a file
-  !! Extension will be determined by the format printer
-  call out % writeToFile("./path/to/output/without_any_extension")
+  !! We need to make sure that output file is properly finalised. We can skip
+  !! this line if we we are not in a `program` block e.g. in `subroutine` or `function`
+  call out % finalise()
+
 
 The need to write name to a `character(nameLen)` variable before calling the procedure is a quirk
 caused by the fact that the output file expects character of `nameLen` as a variable. If one were to

--- a/docs/Output.rst
+++ b/docs/Output.rst
@@ -78,7 +78,7 @@ Writing to an output file in SCONE is done through a series of calls to appropri
   call out % endBlock()
 
   !! We need to make sure that output file is properly finalised. We can skip
-  !! this line if we we are not in a `program` block e.g. in `subroutine` or `function`
+  !! this line if we are not in a `program` block e.g. in `subroutine` or `function`
   call out % finalise()
 
 


### PR DESCRIPTION
This resolves Issue #38.  However, I cannot help but to think it is a bit filthy... that being said I am not sure how exactly to make it nicer. 

The problem with streaming to the output file directly is that it is convenient to have a 'backtrace' capability, when writing the printers for different output formats. This allows, for example, to remove trailing commas with relative ease (crucial for JSON). 

To 'have a cake and eat it' this implements a `delayedStream` which works a bit like a buffered output, but when the buffer is flushed it retains `MIN_SIZE=16` last characters [as opposed to printing everything to the disk]. 

What I don't like about the changes is the way the file ownership is handled. It is made to be a responsibility of the `outputFile` class, which opens a file in `init`and closes it in `finalisation` (which is also the destructor). However, the printing is implemented by the `asciiOutput_inter` which owns an instance of `delayedStream`. The appropriate output unit is set by a subroutine.  

The other thing I fear may be confusing is that if one does not supply `filename` to `outputFile` no file will be produced (this is required for unit testing). 

In short this PR may still require some iterations [in addition to squashing the fixups!]           