### PR TITLE
Add debug and a build with no openmp to the CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,3 +24,31 @@ jobs:
           make -j
           make test
           cd -
+  build-and-test-debug:
+    runs-on: ubuntu-20.04
+    container:
+      image: mikolajkowalski/scone-test:gfortran10
+    steps:
+      - uses: actions/checkout@v3
+      - name: CompileAndTest
+        run : |
+          mkdir build
+          cd build
+          cmake -DDEBUG=ON ..
+          make -j
+          make test
+          cd -
+  build-and-test-no-openmp:
+    runs-on: ubuntu-20.04
+    container:
+      image: mikolajkowalski/scone-test:gfortran10
+    steps:
+      - uses: actions/checkout@v3
+      - name: CompileAndTest
+        run : |
+          mkdir build
+          cd build
+          cmake -DOPENMP=OFF ..
+          make -j
+          make test
+          cd -

--- a/Tallies/TallyClerks/Tests/mgXsClerk_test.f90
+++ b/Tallies/TallyClerks/Tests/mgXsClerk_test.f90
@@ -33,6 +33,7 @@ contains
   subroutine setUp(this)
     class(test_mgXsClerk), intent(inout) :: this
     type(dictionary)                     :: tempDict, energyDict, spaceDict
+    character(nameLen)                   :: temp
 
     ! Build energy map
     call energyDict % init(3)
@@ -50,7 +51,8 @@ contains
     call tempDict % store('energyMap', energyDict)
     call tempDict % store('spaceMap', spaceDict)
 
-    call this % clerk_test1 % init(tempDict,'MGxs1')
+    temp = 'MGxs1'
+    call this % clerk_test1 % init(tempDict, temp)
     call spaceDict % kill()
     call energyDict % kill()
     call tempDict % kill()
@@ -66,7 +68,8 @@ contains
     call tempDict % store('energyMap', energyDict)
     call tempDict % store('PN', 0)
 
-    call this % clerk_test2 % init(tempDict,'MGxs2')
+    temp = 'MGxs2'
+    call this % clerk_test2 % init(tempDict, temp)
     call energyDict % kill()
     call tempDict % kill()
 

--- a/Tallies/TallyMaps/Tests/cellMap_test.f90
+++ b/Tallies/TallyMaps/Tests/cellMap_test.f90
@@ -81,7 +81,8 @@ contains
     call mm_nameMap % add(name, VOID_MAT)
 
     ! Initialise geometry in geomReg
-    call new_geometry(dict, 'geom', silent = .true.)
+    name = 'geom'
+    call new_geometry(dict, name, silent = .true.)
 
     ! Initialise dictionaries
     call mapDict1 % init(2)


### PR DESCRIPTION
Adds to additional build and test jobs that verify if SCONE compiles and passes tests with `DEBUG` option set to ON as well as with OpenMP switched off. 

Only a single compiler for each case is used. I don't know if it might be worth to extend it to all compilers. I am a bit paranoid about the usage of the GitHub Actions resources.  

P.S. Resolves #48 