### PR TITLE
Fix one thread OMP reproducibility

### DIFF
--- a/ParticleObjects/Source/source_inter.f90
+++ b/ParticleObjects/Source/source_inter.f90
@@ -100,8 +100,9 @@ contains
       type(particleDungeon), intent(inout) :: dungeon
       integer(shortInt), intent(in)        :: n
       class(RNG), intent(in)               :: rand
-      type(RNG)                            :: pRand
+      type(RNG), save                      :: pRand
       integer(shortInt)                    :: i
+      !$omp threadprivate(pRand)
 
       ! Set dungeon size to begin
       call dungeon % setSize(n)
@@ -111,7 +112,7 @@ contains
       !       This should prevent reusing RNs during transport
       !$omp parallel
       pRand = rand
-      !$omp do private(pRand)
+      !$omp do
       do i = 1, n
         call pRand % stride(i)
         call dungeon % replace(self % sampleParticle(pRand), i)


### PR DESCRIPTION
I noted that reproducibility seemed to be broken when OpenMP is enabled. While it is expected for runs with multiple threads, it was happening for a single thread as well. 

As expected it turned out to be a typo. The `pRand` variable was being used uninitialised as a result of the type in the set-up of directives. 

I guess the only question is if we wish to integrate the fix quickly or push this PR to have a full OpenMP reproducibility (regardless of the number of threads)? 