### PR TITLE
Fix to mgXsClerk

### DIFF
--- a/Tallies/TallyClerks/mgXsClerk_class.f90
+++ b/Tallies/TallyClerks/mgXsClerk_class.f90
@@ -236,7 +236,7 @@ contains
     end if
 
     ! Return if invalid bin index
-    if (enIdx == 0 .or. matIdx == 0) return
+    if ((enIdx == self % energyN + 1) .or. matIdx == 0) return
 
     ! Calculate bin address
     binIdx = self % energyN * (matIdx - 1) + enIdx
@@ -324,7 +324,7 @@ contains
         end if
 
         ! Return if invalid bin index
-        if (enIdx == 0 .or. matIdx == 0) return
+        if ((enIdx == self % energyN + 1) .or. matIdx == 0) return
 
         ! Calculate bin address
         binIdx = self % energyN * (matIdx - 1) + enIdx
@@ -341,7 +341,7 @@ contains
         end if
 
         ! Return if invalid bin index
-        if (binEnOut == 0) return
+        if (binEnOut == self % energyN + 1) return
 
         ! Score scattering event from group g to g'
         call mem % score(preColl % wgt, addr + SCATT_EV_idx + binEnOut)
@@ -429,7 +429,7 @@ contains
       end if
 
       ! Return if invalid bin index
-      if (enIdx == 0 .or. matIdx == 0) cycle
+      if ((enIdx == self % energyN + 1) .or. matIdx == 0) cycle
 
       ! Calculate bin address
       binIdx = self % energyN * (matIdx - 1) + enIdx


### PR DESCRIPTION
There was an error in the mg clerk which would fail to recognise when an entry was out of bounds. This was due to having an incorrect 'exit' condition on the tally - naturally it would be a check for a map index of 0, but because of flipping the energy groups around (for postprocessing convenience) this should actually be a check for nG + 1. This now runs and unit tests pass.