### PR TITLE
Update mgXsClerk_class.f90

### DIFF
--- a/Tallies/TallyClerks/mgXsClerk_class.f90
+++ b/Tallies/TallyClerks/mgXsClerk_class.f90
@@ -739,7 +739,7 @@ contains
     end if
 
     ! Print energy map information
-    if (allocated(self % energyMap)) self % energyMap % print(outFile)
+    if (allocated(self % energyMap)) call self % energyMap % print(outFile)
     resArrayShape(1) = self % energyN
 
     ! If a space map print map information

--- a/Tallies/TallyClerks/mgXsClerk_class.f90
+++ b/Tallies/TallyClerks/mgXsClerk_class.f90
@@ -739,12 +739,8 @@ contains
     end if
 
     ! Print energy map information
-    if (allocated(self % energyMap)) then
-      call self % energyMap % print(outFile)
-      resArrayShape(1) = self % energyN
-    else
-      resArrayShape(1) = 1
-    end if
+    if (allocated(self % energyMap)) self % energyMap % print(outFile)
+    resArrayShape(1) = self % energyN
 
     ! If a space map print map information
     if (allocated(self % spaceMap)) then

--- a/Tallies/TallyClerks/mgXsClerk_class.f90
+++ b/Tallies/TallyClerks/mgXsClerk_class.f90
@@ -739,8 +739,12 @@ contains
     end if
 
     ! Print energy map information
-    call self % energyMap % print(outFile)
-    resArrayShape(1) = self % energyN
+    if (allocated(self % energyMap)) then
+      call self % energyMap % print(outFile)
+      resArrayShape(1) = self % energyN
+    else
+      resArrayShape(1) = 1
+    end if
 
     ! If a space map print map information
     if (allocated(self % spaceMap)) then


### PR DESCRIPTION
Fix to prevent seg fault when no energy map is given. Adds a check for whether the energyMap is allocated and behaves accordingly.