### PR TITLE
Fix a bug in dictParser

### DIFF
--- a/DataStructures/dictParser_func.f90
+++ b/DataStructures/dictParser_func.f90
@@ -95,11 +95,13 @@ contains
       !
       if (buffer == '!') then
         read(unit=unit, fmt='(A)', iostat=stat, advance='yes') buffer
+        buffer = ' '
 
       else if (lastChar == '/' .and. buffer == '/') then
         ! We need to remove the last character
         call file % cut(1)
         read(unit=unit, fmt='(A)', iostat=stat, advance='yes') buffer
+        buffer = ' '
 
       end if
 

--- a/IntegrationTestFiles/testDictionary
+++ b/IntegrationTestFiles/testDictionary
@@ -5,6 +5,8 @@ intArray (1 2 4 5);
 realArray (      1
                2.2  3.5 )   ; // a bit of weird formatting
 charArray (One element );
+!Another comment
 subDict{ myInt 3; myReal 3.2; } ! Note lack of space
 
+//Line comment without space after marker. This case caused a bug at some point
 subDict2 { myInt 4; myReal 17.0;}


### PR DESCRIPTION
Behaviour in case of a comment without a space after marker was incorrect:
```
//Line comment 
key val1;
```
The 'L' would have been read from the file. Now the line comments are removed correctly.