### PR TITLE
Move reading of id, origin and rotation to `universe_inter`

### DIFF
--- a/Geometry/Universes/Tests/cellUniverse_test.f90
+++ b/Geometry/Universes/Tests/cellUniverse_test.f90
@@ -42,7 +42,7 @@ module cellUniverse_test
 contains
 
   !!
-  !! Setup enviroment
+  !! Setup environment
   !!
 @Before
   subroutine setUp()
@@ -73,7 +73,7 @@ contains
   end subroutine setUp
 
   !!
-  !! Clean enviroment
+  !! Clean environment
   !!
 @After
   subroutine clean()
@@ -201,7 +201,7 @@ contains
     @assertEqual(ref, d, TOL * ref)
     @assertEqual(surfs % getIdx(2), surfIdx )
 
-    ! ** In local cell 2 distance to infintity
+    ! ** In local cell 2 distance to infinity
     ! surfIdx must be set to 0
     pos % dir = [ONE, ZERO, ZERO]
     call uni % distance(d, surfIdx, pos)

--- a/Geometry/Universes/Tests/latUniverse_test.f90
+++ b/Geometry/Universes/Tests/latUniverse_test.f90
@@ -38,7 +38,7 @@ module latUniverse_test
 contains
 
   !!
-  !! Setup enviroment
+  !! Setup environment
   !!
 @Before
   subroutine setUp()
@@ -73,7 +73,7 @@ contains
   end subroutine setUp
 
   !!
-  !! Clean enviroment
+  !! Clean environment
   !!
 @After
   subroutine clean()

--- a/Geometry/Universes/Tests/pinUniverse_test.f90
+++ b/Geometry/Universes/Tests/pinUniverse_test.f90
@@ -27,7 +27,7 @@ module pinUniverse_test
 contains
 
   !!
-  !! Set-up test enviroment
+  !! Set-up test environment
   !!
 @Before
   subroutine setup()

--- a/Geometry/Universes/Tests/rootUniverse_test.f90
+++ b/Geometry/Universes/Tests/rootUniverse_test.f90
@@ -30,7 +30,7 @@ module rootUniverse_test
 contains
 
   !!
-  !! Setup enviroment
+  !! Setup environment
   !!
 @Before
   subroutine setUp()
@@ -57,7 +57,7 @@ contains
   end subroutine setUp
 
   !!
-  !! Clean enviroment
+  !! Clean environment
   !!
 @After
   subroutine clean()

--- a/Geometry/Universes/Tests/uniFills_test.f90
+++ b/Geometry/Universes/Tests/uniFills_test.f90
@@ -110,7 +110,7 @@ contains
 
     @assertTrue(graph % hasCycles())
 
-    ! Move recursion to 3rd diffrent universe (loop from 3rd to 2nd)
+    ! Move recursion to 3rd different universe (loop from 3rd to 2nd)
     !
     graph % uni(2) % fill(1) = 3
     graph % uni(3) % fill(1) = -2

--- a/Geometry/Universes/Tests/universe_test.f90
+++ b/Geometry/Universes/Tests/universe_test.f90
@@ -7,7 +7,7 @@ module universe_test
 
 
   !!
-  !! Note that universe is abstract thus it canot be tested by itself
+  !! Note that universe is abstract thus it cannot be tested by itself
   !!
   !! Tests for universe non-overridable procedures are in cellUniverse_test
   !!
@@ -36,7 +36,7 @@ contains
     name = 'mat47'
     call mats % add(name, 47)
 
-    ! Test material converstion
+    ! Test material conversion
     name = 'mat13'
     @assertEqual(13, charToFill(name, mats, Here))
 

--- a/Geometry/Universes/cellUniverse_class.f90
+++ b/Geometry/Universes/cellUniverse_class.f90
@@ -28,7 +28,7 @@ module cellUniverse_class
   !!
   !! Representation of a universe via cells
   !!
-  !! Each local cell in the universe corespondes to a cell given by an ID.
+  !! Each local cell in the universe corresponds to a cell given by an ID.
   !! An extra local cell is always defined inside the cellUniverse with UNDEF_MAT
   !! (undefined material) filling. If position is not in any user-defined cell, it is in this
   !! extra cell. Extra cell exists to enable plotting of geometry without fatalErrors.
@@ -168,8 +168,8 @@ contains
   !!
   !! See universe_inter for details.
   !!
-  !! Note: Introduces extra movment to the particle to push it over boundary
-  !!   for more efficent search. Distance is NUGDE.
+  !! Note: Introduces extra movement to the particle to push it over boundary
+  !!   for more efficient search. Distance is NUGDE.
   !!
   subroutine cross(self, coords, surfIdx)
     class(cellUniverse), intent(inout) :: self

--- a/Geometry/Universes/cellUniverse_class.f90
+++ b/Geometry/Universes/cellUniverse_class.f90
@@ -78,35 +78,12 @@ contains
     type(surfaceShelf), intent(inout)                         :: surfs
     type(charMap), intent(in)                                 :: mats
     integer(shortInt), dimension(:), allocatable  :: cellTemp
-    real(defReal), dimension(:), allocatable      :: temp
-    integer(shortInt)                             :: id, N, i
+    integer(shortInt)                             :: N, i
     character(100), parameter :: Here = 'init (cellUniverse_class.f90)'
 
-    ! Load basic data
-    call dict % get(id, 'id')
-    if (id <= 0) call fatalError(Here, 'Universe ID must be +ve. Is: '//numToChar(id))
-    call self % setId(id)
-
-    ! Load origin
-    if (dict % isPresent('origin')) then
-      call dict % get(temp, 'origin')
-
-      if (size(temp) /= 3) then
-        call fatalError(Here, 'Origin must have size 3. Has: '//numToChar(size(temp)))
-      end if
-      call self % setTransform(origin=temp)
-
-    end if
-
-    ! Load rotation
-    if (dict % isPresent('rotation')) then
-      call dict % get(temp, 'rotation')
-
-      if (size(temp) /= 3) then
-        call fatalError(Here, '3 rotation angles must be given. Has only: '//numToChar(size(temp)))
-      end if
-      call self % setTransform(rotation=temp)
-    end if
+    ! Setup the base class
+    ! With: id, origin rotations...
+    call self % setupBase(dict)
 
     ! Load Cells by ID
     call dict % get(cellTemp, 'cells')

--- a/Geometry/Universes/latUniverse_class.f90
+++ b/Geometry/Universes/latUniverse_class.f90
@@ -111,37 +111,15 @@ contains
     type(charMap), intent(in)                                 :: mats
     real(defReal), dimension(:), allocatable       :: temp
     integer(shortInt), dimension(:), allocatable   :: tempI
-    integer(shortInt)                              :: id, N, i, j, outFill
+    integer(shortInt)                              :: N, i, j, outFill
     type(dictionary)                               :: tempDict
     integer(shortInt), dimension(:,:), allocatable :: tempMap
     character(nameLen)                             :: name
     character(100), parameter :: Here = 'init (latUniverse_class.f90)'
 
-    ! Load basic data
-    call dict % get(id, 'id')
-    if (id <= 0) call fatalError(Here, 'Universe ID must be +ve. Is: '//numToChar(id))
-    call self % setId(id)
-
-    ! Load origin
-    if (dict % isPresent('origin')) then
-      call dict % get(temp, 'origin')
-
-      if (size(temp) /= 3) then
-        call fatalError(Here, 'Origin must have size 3. Has: '//numToChar(size(temp)))
-      end if
-      call self % setTransform(origin=temp)
-
-    end if
-
-    ! Load rotation
-    if (dict % isPresent('rotation')) then
-      call dict % get(temp, 'rotation')
-
-      if (size(temp) /= 3) then
-        call fatalError(Here, '3 rotation angles must be given. Has only: '//numToChar(size(temp)))
-      end if
-      call self % setTransform(rotation=temp)
-    end if
+    ! Setup the base class
+    ! With: id, origin rotations...
+    call self % setupBase(dict)
 
     ! Load pitch
     call dict % get(temp, 'pitch')
@@ -308,7 +286,7 @@ contains
     ! Provide default axis to ensure no out of bounds array access if
     ! all distances happen to be infinite
     d = INF
-    ax = 1 
+    ax = 1
     do i = 1, 3
       ! Nominator and denominator will have the same sign (by ealier bounds selection)
       test_d = (bounds(i) - r_bar(i)) / u(i)

--- a/Geometry/Universes/latUniverse_class.f90
+++ b/Geometry/Universes/latUniverse_class.f90
@@ -31,7 +31,7 @@ module latUniverse_class
   !! Cells inside the lattice can only be filled with a universe (given as integer ID).
   !! Background cell can have any filling given by keyword (material or universe)
   !!
-  !! Every lattice cell has an offset to its centere (so the centre of the nested universe
+  !! Every lattice cell has an offset to its centre (so the centre of the nested universe
   !! is in the center of the lattice cell).
   !!
   !! Minimum lattice pitch is set to 10 * SURF_TOL
@@ -66,7 +66,7 @@ module latUniverse_class
   !! Private Members:
   !!  pitch      -> Values of lattice pitch in x, y & z directions
   !!  sizeN      -> Number of lattice cells in x, y & z directions
-  !!  corner     -> Location of the minumum corner
+  !!  corner     -> Location of the minimum corner
   !!  a_bar      -> Halfwidth of lattice cell reduced by surface tolerance
   !!  outline    -> Box type surface that is a boundary between lattice & background
   !!  outLocalID -> LocalID of the background cell
@@ -288,7 +288,7 @@ contains
     d = INF
     ax = 1
     do i = 1, 3
-      ! Nominator and denominator will have the same sign (by ealier bounds selection)
+      ! Nominator and denominator will have the same sign (by earlier bounds selection)
       test_d = (bounds(i) - r_bar(i)) / u(i)
 
       if (test_d < d) then

--- a/Geometry/Universes/pinUniverse_class.f90
+++ b/Geometry/Universes/pinUniverse_class.f90
@@ -77,36 +77,14 @@ contains
     type(cellShelf), intent(inout)                            :: cells
     type(surfaceShelf), intent(inout)                         :: surfs
     type(charMap), intent(in)                                 :: mats
-    integer(shortInt)                             :: id, idx, N, i
-    real(defReal), dimension(:), allocatable      :: radii, temp
+    integer(shortInt)                             :: idx, N, i
+    real(defReal), dimension(:), allocatable      :: radii
     character(nameLen), dimension(:), allocatable :: fillNames
     character(100), parameter :: Here = 'init (pinUniverse_class.f90)'
 
-    ! Load basic data
-    call dict % get(id, 'id')
-    if (id <= 0) call fatalError(Here, 'Universe ID must be +ve. Is: '//numToChar(id))
-    call self % setId(id)
-
-    ! Load origin
-    if (dict % isPresent('origin')) then
-      call dict % get(temp, 'origin')
-
-      if (size(temp) /= 3) then
-        call fatalError(Here, 'Origin must have size 3. Has: '//numToChar(size(temp)))
-      end if
-      call self % setTransform(origin=temp)
-
-    end if
-
-    ! Load rotation
-    if (dict % isPresent('rotation')) then
-      call dict % get(temp, 'rotation')
-
-      if (size(temp) /= 3) then
-        call fatalError(Here, '3 rotation angles must be given. Has only: '//numToChar(size(temp)))
-      end if
-      call self % setTransform(rotation=temp)
-    end if
+    ! Setup the base class
+    ! With: id, origin rotations...
+    call self % setupBase(dict)
 
     ! Load radii and fill data
     call dict % get(radii, 'radii')

--- a/Geometry/Universes/pinUniverse_class.f90
+++ b/Geometry/Universes/pinUniverse_class.f90
@@ -34,14 +34,14 @@ module pinUniverse_class
   !!     fills (u<3> void clad u<4>);
   !!   }
   !!
-  !!  There must be 0.0 entry, which indicates outermost annulus (infinate radius).
+  !!  There must be 0.0 entry, which indicates outermost annulus (infinite radius).
   !!  `fills` and `radii` are given as pairs by position in the input arrays. Thus, fills
   !!  are sorted together with the `radii`. As a result, in the example, local cell 1 is
   !!  filled with u<4>, cell 2 with u<3> etc.
   !!
   !! Public Members:
   !!  r_sqr  -> Array of radius^2 for each annulus
-  !!  annuli -> Array of cylinder surfaces that represent diffrent annuli
+  !!  annuli -> Array of cylinder surfaces that represent different annuli
   !!
   !! Interface:
   !!   universe interface
@@ -104,7 +104,7 @@ contains
     ! Change 0.0 to infinity
     N = size(radii)
     idx = minloc(radii, 1)
-    if (radii(idx) /= ZERO) call fatalError(Here, 'Did not found outermst element with radius 0.0.')
+    if (radii(idx) /= ZERO) call fatalError(Here, 'Did not found outermost element with radius 0.0.')
     call swap( radii(idx), radii(N))
     call swap( fillNames(idx), fillNames(N))
     radii(N) = INF * 1.1_defReal

--- a/Geometry/Universes/rootUniverse_class.f90
+++ b/Geometry/Universes/rootUniverse_class.f90
@@ -84,12 +84,11 @@ contains
     character(nameLen)                                        :: name
     character(100), parameter :: Here = 'init (rootUniverse_class.f90)'
 
-    ! Set ID
-    call dict % get(id, 'id')
-    if (id <= 0) call fatalError(Here, 'Universe ID must be +ve. Is: '//numToChar(id))
-    call self % setId(id)
+    ! Setup the base class
+    ! With: id, origin rotations...
+    call self % setupBase(dict)
 
-    ! Make shure root does not contain neither origin nor rotation
+    ! Make sure root does not contain neither origin nor rotation
     if (dict % isPresent('origin')) then
       call fatalError(Here, 'Origin is not allowed. Centre of the root universe is &
                             &always (0.0 0.0 0.0).')

--- a/Geometry/Universes/rootUniverse_class.f90
+++ b/Geometry/Universes/rootUniverse_class.f90
@@ -92,7 +92,7 @@ contains
     if (dict % isPresent('origin')) then
       call fatalError(Here, 'Origin is not allowed. Centre of the root universe is &
                             &always (0.0 0.0 0.0).')
-    else if (dict % isPresent('origin')) then
+    else if (dict % isPresent('rotation')) then
       call fatalError(Here, 'Rotation is not allowed. Root universe cannot be rotated.')
 
     end if

--- a/Geometry/Universes/rootUniverse_class.f90
+++ b/Geometry/Universes/rootUniverse_class.f90
@@ -22,7 +22,7 @@ module rootUniverse_class
   !!
   !! A top level (root) universe of geometry
   !!
-  !! Is composed of two regions. Inside and outside seperated by a single surface.
+  !! Is composed of two regions. Inside and outside separated by a single surface.
   !! Inside is the -ve halfspace of the boundary surface
   !! +ve halfspace is OUTSIDE
   !! Filling can be universe given by ID (`u<67` syntax) or a material given by name (e.g. 'fuel')

--- a/Geometry/Universes/uniFills_class.f90
+++ b/Geometry/Universes/uniFills_class.f90
@@ -30,12 +30,12 @@ module uniFills_class
   !! A Temporary structure to store universe fillings & check correctness
   !!
   !! Is used to transfer information about universe nesting structure decoupled from
-  !! the spatial subdivision. Will be used to constrct geomGraph.
+  !! the spatial subdivision. Will be used to construct geomGraph.
   !!
   !! TODO: The recursive procedures that do checks may not be the best from the point of
   !!   view of efficiency. Investigate if it is a problem.
   !!
-  !! Public Mambers:
+  !! Public Members:
   !!  root -> Index of the root universe
   !!  uni  -> Array of `fillInfo` with data for each universe. Universe indices are the
   !!    same on the uni array on on the universe Shelf.
@@ -304,7 +304,7 @@ contains
       call fatalError(Here, 'Root universe has not been set.')
     end if
 
-    ! Serach nested universes
+    ! Search nested universes
     hasIt = .false.
     do i = 1, size(self % uni(self % root) % fill)
       fill = self % uni(self % root) % fill(i)
@@ -360,7 +360,7 @@ contains
   end function unusedUniverses
 
   !!
-  !! Get count of instances of diffrent universes in the geometry
+  !! Get count of instances of different universes in the geometry
   !!
   !! Args:
   !!   map [out] -> Map of uniIdx to number of instances. If uniIdx is not present in the
@@ -483,7 +483,7 @@ contains
   !!   idx [in] -> Index of the current universe
   !!
   !! Result:
-  !!   True if universe under idx contains outside or outisde is present below it
+  !!   True if universe under idx contains outside or outside is present below it
   !!
   !! Errors:
   !!   fatalError if idx is invalid
@@ -554,7 +554,7 @@ contains
   end subroutine collectUsed
 
   !!
-  !! Count instances of diffrent univeres in the current universe or below it
+  !! Count instances of different universes in the current universe or below it
   !!
   !! Args:
   !!   map [inout] -> Map of uniIdx to number of instances. Instances in the current universe
@@ -578,7 +578,7 @@ contains
     count = map % getOrDefault(idx, 0) + 1
     call map % add(idx, count)
 
-    ! Loop over local cells and add nexted universes
+    ! Loop over local cells and add nested universes
     do i = 1, size(self % uni(idx) % fill)
       fill = self % uni(idx) % fill(i)
 

--- a/Geometry/Universes/universeFactory_func.f90
+++ b/Geometry/Universes/universeFactory_func.f90
@@ -37,7 +37,7 @@ contains
   !!
   !! Args:
   !!  ptr [out]     -> Pointer to the new universe
-  !!  fill [out]    -> Allocatable integer array with filling of diffrent uniqueID
+  !!  fill [out]    -> Allocatable integer array with filling of different uniqueID
   !!  dict [in]     -> Dictionary with universe definition
   !!  cells [inout] -> Shelf with defined cells
   !!  surfs [inout] -> Shelf  with defined surfaces
@@ -59,7 +59,7 @@ contains
     ! Obtain type of the universe
     call dict % get(type, 'type')
 
-    ! Allocate approperiate universe
+    ! Allocate appropriate universe
     ! ** FOR NEW UNIVERSE ADD CASE STATEMENT HERE ** !
     select case (type)
       case ('rootUniverse')
@@ -87,11 +87,11 @@ contains
   end subroutine new_universe_ptr
 
   !!
-  !! Allocte an allocatable universe
+  !! Allocate an allocatable universe
   !!
   !! Args:
   !!  new [out]     -> Universe to be allocated
-  !!  fill [out]    -> Allocatable integer array with filling of diffrent uniqueID
+  !!  fill [out]    -> Allocatable integer array with filling of different uniqueID
   !!  dict [in]     -> Dictionary with universe definition
   !!  cells [inout] -> Shelf with defined cells
   !!  surfs [inout] -> Shelf  with defined surfaces

--- a/Geometry/Universes/universeShelf_class.f90
+++ b/Geometry/Universes/universeShelf_class.f90
@@ -46,13 +46,13 @@ module universeShelf_class
   !!   init    -> Initialise and build uniFills
   !!   getPtr  -> Get pointer to a universe given by its index
   !!   getPtr_fast -> Get pointer to a universe without bounds checking. Should be used in
-  !!     speed-critical parts. 
+  !!     speed-critical parts.
   !!   getIdx  -> Get uniIdx of a universe given by uniId
   !!   getId   -> Get uniId of a universe given by uniIdx
   !!   getSize -> Return the number of universes (max uniIdx)
   !!   kill    -> Return to uninitialised state
   !!
-  !! NOTE: Becoue universes are stored as pointers, calling `kill` is crucial
+  !! NOTE: Because universes are stored as pointers, calling `kill` is crucial
   !!   to prevent memory leaks. TODO: Add `final` procedure here?
   !!
   type, public :: universeShelf
@@ -132,7 +132,7 @@ contains
       ! Store content info in fills
       call fills % addUniverse(i, id, fillInfo)
 
-      ! Load index infor into the universe
+      ! Load index info into the universe
       call self % unis(i) % ptr % setIdx(i)
 
     end do
@@ -153,7 +153,7 @@ contains
   !!
   !! Errors:
   !!   Pointer will have undefined status if the idx is not valid (will point to some place
-  !!   it is unlikley it will be null so associated procedure may return true!)
+  !!   it is unlikely it will be null so associated procedure may return true!)
   !!
   function getPtr_fast(self, idx) result(ptr)
     class(universeShelf), intent(in) :: self

--- a/Geometry/Universes/universe_inter.f90
+++ b/Geometry/Universes/universe_inter.f90
@@ -12,7 +12,7 @@ module universe_inter
   private
 
 
-  ! Extandable methods
+  ! Extendable methods
   public :: kill
 
   ! Universe utility functions
@@ -40,7 +40,7 @@ module universe_inter
   !! Private Members:
   !!   uniId   -> Id of the universe
   !!   uniIdx  -> Index of the universe
-  !!   origin  -> Location of the origin of the univere co-ordinates in the frame of higher universe
+  !!   origin  -> Location of the origin of the universe co-ordinates in the frame of higher universe
   !!   rotMat  -> Rotation matrix for rotation with respect to the higher universe
   !!   rot     -> rotation flag. True is universe is rotated
   !!
@@ -50,7 +50,7 @@ module universe_inter
   !!   setIdx       -> Set index of the universe
   !!   setTransfrom -> Set origin and/or rotation of the universe. Rotation angles are in [deg]
   !!   init         -> Initialise universe and return fillArray with content of local cells.
-  !!     Requires surface/cell shelfs and map of material names to matIdxs
+  !!     Requires surface/cell shelves and map of material names to matIdxs
   !!   kill         -> Return to uninitialised state
   !!   enter        -> Generate new coord after entering a universe from higher level coord.
   !!   findCell     -> Return local cell ID and cellIdx in cellShelf for a given position.
@@ -88,7 +88,7 @@ module universe_inter
     !!
     !! Initialise Universe
     !!
-    !! Must ruturn a fill array, that contains content in each local cell of the universe.
+    !! Must return a fill array, that contains content in each local cell of the universe.
     !! Array is indexed by local cell ID. Universe content is -uniID and material content
     !! is +ve matIdx.
     !!
@@ -123,7 +123,7 @@ module universe_inter
     !!   cellIdx [out] -> cellIdx in cellShelf, if the cell point is in is defined there.
     !!     If the cell exists only in the universe return 0.
     !!   r [in]        -> Position of a point
-    !!   u [in]        -> Normalised direaction (norm2(u) = 1.0)
+    !!   u [in]        -> Normalised direction (norm2(u) = 1.0)
     !!
     !! Note: Self is intent(inout), but if a state of the universe is to be changed
     !!   it is necessary to consider issues related to parallel calculations with shared
@@ -152,7 +152,7 @@ module universe_inter
     !! Args:
     !!   d [out]       -> Distance to the next surface
     !!   surfIdx [out] -> Index of the surface that will be crossed. If +ve than surface
-    !!     is defined on surfaceSHelf. If -ve surface is local to this univerese.
+    !!     is defined on surfaceSHelf. If -ve surface is local to this universe.
     !!   coords [in]   -> Coordinates of the point inside the universe (after transformations
     !!     and with localID already set)
     !!
@@ -172,12 +172,12 @@ module universe_inter
     !! Cross between local cells
     !!
     !! Procedure assumes that the point is ON THE SURFACE between cells within under/overshoot as
-    !! a result of finate FP precision.
+    !! a result of finite FP precision.
     !!
     !! Args:
     !!   coords [inout] -> Coordinates placed in the universe (after transformations and with
     !!     local ID set). On exit localID will be changed
-    !!   surfIdx [in]   -> surfIdx from distance procedure, which hints which surface is beeing
+    !!   surfIdx [in]   -> surfIdx from distance procedure, which hints which surface is being
     !!     crossed.
     !!
     !! Note: Self is intent(inout), but if a state of the universe is to be changed
@@ -352,7 +352,7 @@ contains
   !! Sets:
   !!   - New position (r)
   !!   - New direction (dir)
-  !!   - Rotation infor (isRotated + rotMat)
+  !!   - Rotation info (isRotated + rotMat)
   !!   - Local cell (localID)
   !!   - Cell info (cellIdx)
   !!
@@ -362,7 +362,7 @@ contains
   !!
   !! Args:
   !!   new [out] -> New coordinates for the level.
-  !!   r [in] -> Position affter cellOffset in upper univere is applied
+  !!   r [in] -> Position after cellOffset in upper universe is applied
   !!   u [in] -> Normalised direction (norm2(u) = 1.0)
   !!
   !! Note: Self is intent(inout), but if a state of the universe is to be changed


### PR DESCRIPTION
Moves the code repeated in each universe subclass that sets up the properties of the base `universe` class to a separate, common function. 

This allows to avoid code repeat and will make the extension (to e.g. time-dependent transformations) easier.  