### PR TITLE
Allow '-' '_' characters in SAB ace card name

### DIFF
--- a/scripts/make_ace_lib.sh
+++ b/scripts/make_ace_lib.sh
@@ -58,7 +58,7 @@ do
 
   elif [[ $MODE =~ ^SAB$ ]]; then
     awk -v FILE=$FULL_PATH \
-    '/^[[:space:]]*[[:alnum:]]+.[[:digit:]][[:digit:]]t/\
+    '/^[[:space:]]*([[:alnum:]]|_|\-)+.[[:digit:]][[:digit:]]t/\
       {print $1 "; " NR "; " FILE "; "}' $var >> $OUTNAME
 
   else


### PR DESCRIPTION
Fixes the data file generation script in SAB mode. 
Previously the name of the sab ace card was assumed to contain only alphanumeric characters [a-zA-Z0-9]. Clearly this is not the case so the `-` and `_` is allowed as well. 

Do we want to add any extra characters as well?