### PR TITLE
Bug in variance reduction

### DIFF
--- a/CollisionOperator/CollisionProcessors/neutronCEimp_class.f90
+++ b/CollisionOperator/CollisionProcessors/neutronCEimp_class.f90
@@ -500,7 +500,10 @@ contains
     real(defReal), dimension(3)          :: val
     real(defReal)                        :: minWgt, maxWgt, avWgt
 
-    if (p % E < self % minE) then
+    if (p % isDead) then
+    ! Do nothing
+
+    elseif (p % E < self % minE) then
       p % isDead = .true.
 
     ! Weight Windows treatment


### PR DESCRIPTION
In neutronCEimp, the variance reduction inside 'cutoffs' was going on even if the particle was dead. Incredibly I never spotted it, but it was definitely biasing and slowing down things a lot. 