### PR TITLE
Handle virtual collisions [fixed source and transportDT only]

### DIFF
--- a/CollisionOperator/CollisionProcessors/collisionProcessor_inter.f90
+++ b/CollisionOperator/CollisionProcessors/collisionProcessor_inter.f90
@@ -120,7 +120,7 @@ contains
     ! Note: the ordering must not be changed between feeding the particle to the tally
     ! and updating the particle's preCollision state, otherwise this may cause certain 
     ! tallies (e.g., collisionProbability) to return dubious results
-    call tally % reportInColl(p)
+    call tally % reportInColl(p, .false.)
     call p % savePreCollision()
 
     ! Choose collision nuclide and general type (Scatter, Capture or Fission)

--- a/CollisionOperator/collisionOperator_class.f90
+++ b/CollisionOperator/collisionOperator_class.f90
@@ -114,7 +114,7 @@ contains
     class(particleDungeon),intent(inout)     :: thisCycle
     class(particleDungeon),intent(inout)     :: nextCycle
     integer(shortInt)                        :: idx, procType
-    character(100), parameter :: Here = 'collide ( collisionOperator_class.f90)'
+    character(100), parameter :: Here = 'collide (collisionOperator_class.f90)'
 
     ! Select processing index with ternary expression
     if(p % isMG) then

--- a/Tallies/TallyClerks/Tests/collisionClerk_test.f90
+++ b/Tallies/TallyClerks/Tests/collisionClerk_test.f90
@@ -207,11 +207,15 @@ contains
     ! Perform scoring
     call p % setMatIdx(1)
     p % w = 0.7_defReal
-    call clerk % reportInColl(p, nucData, mem)
+    call clerk % reportInColl(p, nucData, mem, .false.)
 
     call p % setMatIdx(6)
     p % w = 1.3_defReal
-    call clerk % reportInColl(p, nucData, mem)
+    call clerk % reportInColl(p, nucData, mem, .false.)
+
+    ! Virtual scoring should not contribute to score in this case
+    p % w = 1000.3_defReal
+    call clerk % reportInColl(p, nucData, mem, .true.)
 
     call mem % closeCycle(ONE)
 
@@ -239,5 +243,119 @@ contains
     call res2Dict % kill()
 
   end subroutine testScoring
+
+@Test(cases=[1,2,3,4,5,6,7,8])
+  subroutine testScoringVirtual(this)
+    class(test_collisionClerk), intent(inout) :: this
+    logical(defBool)                          :: hasFilter, hasMap, has2Res
+    character(:),allocatable                  :: case
+    type(collisionClerk)                      :: clerk
+    type(scoreMemory)                         :: mem
+    type(particle)                            :: p
+    type(testNeutronDatabase)                 :: nucData
+    type(outputFile)                          :: outF
+    type(dictionary)                          :: filterDict, mapDict, res1Dict, res2Dict, clerkDict
+    character(nameLen)                        :: res1Name, res2Name, clerkName
+    integer(shortInt)                         :: i
+    real(defReal)                             :: res
+    real(defReal), parameter :: TOL = 1.0E-9
+
+    ! Copy test settings
+    hasFilter = this % hasFilter
+    hasMap    = this % hasMap
+    has2Res   = this % has2Res
+
+    ! Build case description
+    case = 'Vanilla case with: '
+    if(hasFilter) case = case // ' Filter '
+    if(hasMap)    case = case // ' Map '
+    if(has2Res)   case = case // ' 2nd Response '
+
+    ! Define filter dictionary
+    call filterDict % init(3)
+    call filterDict % store('type','testFilter')
+    call filterDict % store('minIdx',0)
+    call filterDict % store('maxIdx',5)
+
+    ! Define Map dictionary
+    call mapDict % init(2)
+    call mapDict % store('type','testMap')
+    call mapDict % store('maxIdx',7)
+
+    ! Define 1st response dictionary and name
+    res1Name = 'flux'
+    call res1Dict % init(1)
+    call res1Dict % store('type','fluxResponse')
+
+    ! Define 2nd response dictionary and name
+    res2Name ='testResponse'
+    call res2Dict % init(2)
+    call res2Dict % store('type','testResponse')
+    call res2Dict % store('value', 1.3_defReal)
+
+    ! Configure dictionary for the clerk
+    call clerkDict % init(6)
+    call clerkDict % store('type','collisionClerk')
+    call clerkDict % store('handleVirtual', 1)
+    call clerkDict % store(res1Name, res1Dict)
+    call clerkDict % store(res2Name, res2Dict)
+
+    ! Store filter or map
+    if(hasFilter) call clerkDict % store('filter', filterDict)
+    if(hasMap)    call clerkDict % store('map', mapDict)
+
+    ! Store responses used
+    if(has2Res) then
+      call clerkDict % store('response', [res1Name, res2Name])
+    else
+      call clerkDict % store('response', [res1Name])
+    end if
+
+    ! Build Clerk
+    clerkName ='myClerk'
+    call clerk % init(clerkDict, clerkName)
+
+    ! Create score memory
+    call mem % init(int(clerk % getSize(), longInt) , 1)
+    call clerk % setMemAddress(1_longInt)
+
+    ! Build nuclear data
+    call nucData % build(0.3_defReal)
+
+    ! Perform scoring, both virtual and physical should contribute
+    call p % setMatIdx(1)
+    p % w = 0.7_defReal
+    call clerk % reportInColl(p, nucData, mem, .true.)
+
+    call p % setMatIdx(6)
+    p % w = 1.3_defReal
+    call clerk % reportInColl(p, nucData, mem, .false.)
+
+    call mem % closeCycle(ONE)
+
+    ! Verify results of scoring
+    do i=1,size(this % bins)
+      call mem % getResult(res, this % bins(i))
+      @assertEqual(this % results(i), res, TOL, case // 'BIN : ' //numToChar(i) )
+    end do
+
+    ! Verify that size of memory returned is correct
+    @assertEqual(size(this % bins), clerk % getSize(), case // 'Memory size test:')
+
+    ! Verify that output calls are correct
+    call outF % init('dummyPrinter', fatalErrors = .false.)
+    call clerk % print (outF, mem)
+
+    @assertTrue(outF % isValid(), case)
+
+    ! Clean up
+    call nucData % kill()
+    call clerkDict % kill()
+    call filterDict % kill()
+    call mapDict % kill()
+    call res1Dict % kill()
+    call res2Dict % kill()
+
+  end subroutine testScoringVirtual
 
 end module collisionClerk_test

--- a/Tallies/TallyClerks/Tests/collisionProbabilityClerk_test.f90
+++ b/Tallies/TallyClerks/Tests/collisionProbabilityClerk_test.f90
@@ -101,37 +101,37 @@ contains
     call p % setMatIdx(2)
     p % w = 0.7
     p % preCollision % matIdx = 2
-    call this % clerk % reportInColl(p, xsData, mem)
+    call this % clerk % reportInColl(p, xsData, mem, .false.)
 
     ! Particle starts in material 1 and collides in material 2
     call p % setMatIdx(2)
     p % w = 1.1
     p % preCollision % matIdx = 1
-    call this % clerk % reportInColl(p, xsData, mem)
+    call this % clerk % reportInColl(p, xsData, mem, .false.)
 
     ! Particle starts in material 1 and collides in material 1
     call p % setMatIdx(1)
     p % w = 1.0
     p % preCollision % matIdx = 1
-    call this % clerk % reportInColl(p, xsData, mem)
+    call this % clerk % reportInColl(p, xsData, mem, .false.)
 
     ! Particle starts in material 2 and collides in material 1
     call p % setMatIdx(1)
     p % w = 1.4
     p % preCollision % matIdx = 2
-    call this % clerk % reportInColl(p, xsData, mem)
+    call this % clerk % reportInColl(p, xsData, mem, .false.)
 
     ! Particle starts in material 2 and collides in another, unknown material
     call p % setMatIdx(7)
     p % w = 1.0
     p % preCollision % matIdx = 2
-    call this % clerk % reportInColl(p, xsData, mem)
+    call this % clerk % reportInColl(p, xsData, mem, .false.)
 
     ! Particle starts in an unknown material and collides in material 1
     call p % setMatIdx(1)
     p % w = 0.9
     p % preCollision % matIdx = 88
-    call this % clerk % reportInColl(p, xsData, mem)
+    call this % clerk % reportInColl(p, xsData, mem, .false.)
     call this % clerk % reportCycleEnd(pop, mem)
 
     ! Close cycle

--- a/Tallies/TallyClerks/Tests/keffImplicitClerk_test.f90
+++ b/Tallies/TallyClerks/Tests/keffImplicitClerk_test.f90
@@ -83,7 +83,7 @@ contains
     !*** Start cycle 1
     ! Score implicit reaction rates
     p % w = 0.7_defReal
-    call this % clerk % reportInColl(p, this % nucData, mem)
+    call this % clerk % reportInColl(p, this % nucData, mem, .false.)
 
     ! Score analog production
     p % preCollision % wgt = 0.1_defReal
@@ -102,7 +102,7 @@ contains
     !*** Start cycle 2
     ! Score implicit reaction rates
     p % w = 0.6_defReal
-    call this % clerk % reportInColl(p, this % nucData, mem)
+    call this % clerk % reportInColl(p, this % nucData, mem, .false.)
 
     ! Score analog production
     p % preCollision % wgt = 0.1_defReal

--- a/Tallies/TallyClerks/Tests/mgXsClerk_test.f90
+++ b/Tallies/TallyClerks/Tests/mgXsClerk_test.f90
@@ -128,7 +128,7 @@ contains
     call pit % detain(p)
 
     ! Scoring
-    call this % clerk_test1 % reportInColl(p, this % nucData, mem)
+    call this % clerk_test1 % reportInColl(p, this % nucData, mem, .false.)
     call this % clerk_test1 % reportCycleEnd(pit, mem)
 
     p % preCollision % wgt = 0.2_defReal
@@ -203,7 +203,7 @@ contains
     call pit % detain(p)
 
     ! Scoring
-    call this % clerk_test2 % reportInColl(p, this % nucData, mem)
+    call this % clerk_test2 % reportInColl(p, this % nucData, mem, .false.)
     call this % clerk_test2 % reportCycleEnd(pit, mem)
 
     p % preCollision % wgt = 0.2_defReal

--- a/Tallies/TallyClerks/Tests/simpleFMClerk_test.f90
+++ b/Tallies/TallyClerks/Tests/simpleFMClerk_test.f90
@@ -111,17 +111,17 @@ contains
     call p % setMatIdx(2)
     p % w = 0.7
     p % preHistory % matIdx = 2
-    call this % clerk % reportInColl(p, xsData, mem)
+    call this % clerk % reportInColl(p, xsData, mem, .false.)
 
     call p % setMatIdx(1)
     p % w = 1.1
     p % preHistory % matIdx = 2
-    call this % clerk % reportInColl(p, xsData, mem)
+    call this % clerk % reportInColl(p, xsData, mem, .false.)
 
     call p % setMatIdx(1)
     p % w = 1.0
     p % preHistory % matIdx = 1
-    call this % clerk % reportInColl(p, xsData, mem)
+    call this % clerk % reportInColl(p, xsData, mem, .false.)
 
     call this % clerk % reportCycleEnd(pop, mem)
 

--- a/Tallies/TallyClerks/collisionClerk_class.f90
+++ b/Tallies/TallyClerks/collisionClerk_class.f90
@@ -59,6 +59,7 @@ module collisionClerk_class
 
     ! Useful data
     integer(shortInt)  :: width = 0
+    logical(defBool)   :: virtual = .false.
 
   contains
     ! Procedures used during build
@@ -114,6 +115,9 @@ contains
 
     ! Set width
     self % width = size(responseNames)
+
+    ! Handle virtual collisions
+    call dict % getOrDefault(self % virtual,'handleVirtual', .false.)
 
   end subroutine init
 
@@ -178,16 +182,25 @@ contains
   !!
   !! See tallyClerk_inter for details
   !!
-  subroutine reportInColl(self, p, xsData, mem)
+  subroutine reportInColl(self, p, xsData, mem, virtual)
     class(collisionClerk), intent(inout)  :: self
     class(particle), intent(in)           :: p
     class(nuclearDatabase), intent(inout) :: xsData
     type(scoreMemory), intent(inout)      :: mem
+    logical(defBool), intent(in)          :: virtual
     type(particleState)                   :: state
     integer(shortInt)                     :: binIdx, i
     integer(longInt)                      :: adrr
     real(defReal)                         :: scoreVal, flx
     character(100), parameter :: Here =' reportInColl (collisionClerk_class.f90)'
+
+    ! Calculate flux sample based on physical or virtual collision
+    if (self % virtual) then
+      flx = ONE / xsData % getMajorantXS(p)
+    else
+      if (virtual) return
+      flx = ONE / xsData % getTotalMatXS(p, p % matIdx())
+    end if
 
     ! Get current particle state
     state = p
@@ -209,9 +222,6 @@ contains
 
     ! Calculate bin address
     adrr = self % getMemAddress() + self % width * (binIdx -1)  - 1
-
-    ! Calculate flux sample 1/totXs
-    flx = ONE / xsData % getTotalMatXS(p, p % matIdx())
 
     ! Append all bins
     do i=1,self % width

--- a/Tallies/TallyClerks/collisionProbabilityClerk_class.f90
+++ b/Tallies/TallyClerks/collisionProbabilityClerk_class.f90
@@ -168,17 +168,21 @@ contains
   !!
   !! See tallyClerk_inter for details
   !!
-  subroutine reportInColl(self, p, xsData, mem)
+  subroutine reportInColl(self, p, xsData, mem, virtual)
     class(collisionProbabilityClerk), intent(inout) :: self
     class(particle), intent(in)                     :: p
     class(nuclearDatabase),intent(inout)            :: xsData
     type(scoreMemory), intent(inout)                :: mem
+    logical(defBool), intent(in)                    :: virtual
     type(particleState)                             :: state
     integer(shortInt)                               :: sIdx, cIdx
     integer(longInt)                                :: addr
     real(defReal)                                   :: score
     class(neutronMaterial), pointer                 :: mat
     character(100), parameter :: Here = 'reportInColl (collisionProbabilityClerk_class.f90)'
+
+    ! This clerk does not handle virtual scoring yet
+    if (virtual) return
 
     ! Get material or return if it is not a neutron
     mat    => neutronMaterial_CptrCast( xsData % getMaterial(p % matIdx()))

--- a/Tallies/TallyClerks/keffImplicitClerk_class.f90
+++ b/Tallies/TallyClerks/keffImplicitClerk_class.f90
@@ -149,16 +149,20 @@ contains
   !!
   !! See tallyClerk_inter for details
   !!
-  subroutine reportInColl(self, p, xsData, mem)
+  subroutine reportInColl(self, p, xsData, mem, virtual)
     class(keffImplicitClerk), intent(inout)  :: self
     class(particle), intent(in)              :: p
     class(nuclearDatabase),intent(inout)     :: xsData
     type(scoreMemory), intent(inout)         :: mem
+    logical(defBool), intent(in)             :: virtual
     type(neutronMacroXSs)                    :: xss
     class(neutronMaterial), pointer          :: mat
     real(defReal)                            :: totalXS, nuFissXS, absXS, flux
     real(defReal)                            :: s1, s2
     character(100), parameter  :: Here = 'reportInColl (keffImplicitClerk_class.f90)'
+
+    ! This clerk does not handle virtual scoring yet
+    if (virtual) return
 
     ! Obtain XSs
     mat => neutronMaterial_CptrCast(xsData % getMaterial( p % matIdx()))

--- a/Tallies/TallyClerks/mgXsClerk_class.f90
+++ b/Tallies/TallyClerks/mgXsClerk_class.f90
@@ -208,11 +208,12 @@ contains
   !!
   !! See tallyClerk_inter for details
   !!
-  subroutine reportInColl(self, p, xsData, mem)
+  subroutine reportInColl(self, p, xsData, mem, virtual)
     class(mgXsClerk), intent(inout)       :: self
     class(particle), intent(in)           :: p
     class(nuclearDatabase), intent(inout) :: xsData
     type(scoreMemory), intent(inout)      :: mem
+    logical(defBool), intent(in)          :: virtual
     type(particleState)                   :: state
     type(neutronMacroXSs)                 :: xss
     class(neutronMaterial), pointer       :: mat
@@ -220,6 +221,9 @@ contains
     integer(shortInt)                     :: enIdx, matIdx, binIdx
     integer(longInt)                      :: addr
     character(100), parameter :: Here =' reportInColl (mgXsClerk_class.f90)'
+
+    ! This clerk does not handle virtual scoring yet
+    if (virtual) return
 
     ! Get current particle state
     state = p

--- a/Tallies/TallyClerks/simpleFMClerk_class.f90
+++ b/Tallies/TallyClerks/simpleFMClerk_class.f90
@@ -182,17 +182,21 @@ contains
   !!
   !! See tallyClerk_inter for details
   !!
-  subroutine reportInColl(self, p, xsData, mem)
+  subroutine reportInColl(self, p, xsData, mem, virtual)
     class(simpleFMClerk), intent(inout)  :: self
     class(particle), intent(in)          :: p
     class(nuclearDatabase),intent(inout) :: xsData
     type(scoreMemory), intent(inout)     :: mem
+    logical(defBool), intent(in)         :: virtual
     type(particleState)                  :: state
     integer(shortInt)                    :: sIdx, cIdx
     integer(longInt)                     :: addr
     real(defReal)                        :: score
     class(neutronMaterial), pointer      :: mat
     character(100), parameter :: Here = 'reportInColl simpleFMClear_class.f90'
+
+    ! This clerk does not handle virtual scoring yet
+    if (virtual) return
 
     ! Get material or return if it is not a neutron
     mat    => neutronMaterial_CptrCast( xsData % getMaterial(p % matIdx()))

--- a/Tallies/TallyClerks/tallyClerkSlot_class.f90
+++ b/Tallies/TallyClerks/tallyClerkSlot_class.f90
@@ -165,14 +165,15 @@ contains
   !!
   !! See tallyClerk_inter for details
   !!
-  subroutine reportInColl(self, p, xsData, mem)
+  subroutine reportInColl(self, p, xsData, mem, virtual)
     class(tallyClerkSlot), intent(inout)  :: self
     class(particle), intent(in)           :: p
     class(nuclearDatabase), intent(inout) :: xsData
     type(scoreMemory), intent(inout)      :: mem
+    logical(defBool), intent(in)          :: virtual
 
     ! Pass call to instance in the slot
-    call self % slot % reportInColl(p, xsData, mem)
+    call self % slot % reportInColl(p, xsData, mem, virtual)
 
   end subroutine reportInColl
 

--- a/Tallies/TallyClerks/tallyClerk_inter.f90
+++ b/Tallies/TallyClerks/tallyClerk_inter.f90
@@ -216,21 +216,23 @@ contains
   !!
   !! Process incoming collision report
   !!
-  !! See tallyAdmin_class for implicit assumptionas about the report.
+  !! See tallyAdmin_class for implicit assumptions about the report.
   !!
   !! Args:
-  !!   p [in]        -> Partice
-  !!   xsData [inout]-> Nuclear Database with XSs data
-  !!   mem [inout]   -> Score Memory to put results on
+  !!   p [in]         -> Partice
+  !!   xsData [inout] -> Nuclear Database with XSs data
+  !!   mem [inout]    -> Score Memory to put results on
+  !!   virtual [in]   -> Flag indicating virtual collision
   !!
   !! Errors:
   !!   Depend on specific Clerk
   !!
-  subroutine reportInColl(self,p, xsData, mem)
+  subroutine reportInColl(self,p, xsData, mem, virtual)
     class(tallyClerk), intent(inout)      :: self
     class(particle), intent(in)           :: p
     class(nuclearDatabase), intent(inout) :: xsData
     type(scoreMemory), intent(inout)      :: mem
+    logical(defBool), intent(in)          :: virtual
     character(100),parameter    :: Here = 'reportInColl (tallyClerk_inter.f90)'
 
     call fatalError(Here,'Report was send to an instance that does not support it.')

--- a/Tallies/tallyAdmin_class.f90
+++ b/Tallies/tallyAdmin_class.f90
@@ -437,21 +437,23 @@ contains
   !!   Particle is provided just after transition. Before any implicit treatment.
   !!
   !! Args:
-  !!   p [in] -> Particle
+  !!   p [in]       -> Particle
+  !!   virtual [in] -> Flag indicating virtual collision
   !!
   !! Errors:
   !!   None
   !!
-  recursive subroutine reportInColl(self, p)
+  recursive subroutine reportInColl(self, p, virtual)
     class(tallyAdmin), intent(inout) :: self
     class(particle), intent(in)      :: p
+    logical(defBool), intent(in)     :: virtual
     integer(shortInt)                :: i, idx
     class(nuclearDatabase),pointer   :: xsData
     character(100), parameter :: Here = "reportInColl (tallyAdmin_class.f90)"
 
     ! Call attachment
     if(associated(self % atch)) then
-      call reportInColl(self % atch, p)
+      call reportInColl(self % atch, p, virtual)
     end if
 
     ! Get Data
@@ -460,7 +462,7 @@ contains
     ! Go through all clerks that request the report
     do i=1,self % inCollClerks % getSize()
       idx = self % inCollClerks % get(i)
-      call self % tallyClerks(idx) % reportInColl(p, xsData, self % mem)
+      call self % tallyClerks(idx) % reportInColl(p, xsData, self % mem, virtual)
 
     end do
 

--- a/TransportOperator/transportOperatorDT_class.f90
+++ b/TransportOperator/transportOperatorDT_class.f90
@@ -49,7 +49,7 @@ contains
     ! Get majorant XS inverse: 1/Sigma_majorant
     majorant_inv = ONE / self % xsData % getMajorantXS(p)
 
-    ! Should never happen! Prevents Inf distances
+   ! Should never happen! Prevents Inf distances
     if (abs(majorant_inv) > huge(majorant_inv)) call fatalError(Here, "Majorant is 0")
 
     DTLoop:do
@@ -66,7 +66,10 @@ contains
       end if
 
       ! Check for void
-      if( p % matIdx() == VOID_MAT) cycle DTLoop
+      if(p % matIdx() == VOID_MAT) then
+        call tally % reportInColl(p, .true.)
+        cycle DTLoop
+      end if
 
       ! Give error if the particle somehow ended in an undefined material
       if (p % matIdx() == UNDEF_MAT) then
@@ -78,8 +81,12 @@ contains
       sigmaT = self % xsData % getTransMatXS(p, p % matIdx())
 
       ! Roll RNG to determine if the collision is real or virtual
-      ! Exit the loop if the collision is real
-      if (p % pRNG % get() < sigmaT*majorant_inv) exit DTLoop
+      ! Exit the loop if the collision is real, report collision if virtual
+      if (p % pRNG % get() < sigmaT*majorant_inv) then
+        exit DTLoop
+      else
+        call tally % reportInColl(p, .true.)
+      end if
 
     end do DTLoop
 

--- a/TransportOperator/transportOperatorHT_class.f90
+++ b/TransportOperator/transportOperatorHT_class.f90
@@ -91,7 +91,7 @@ contains
     real(defReal)                             :: majorant_inv, sigmaT, distance
     character(100), parameter :: Here = 'deltaTracking (transportOperatorHT_class.f90)'
 
-    ! Get majornat XS inverse: 1/Sigma_majorant
+    ! Get majorant XS inverse: 1/Sigma_majorant
     majorant_inv = ONE / self % xsData % getMajorantXS(p)
 
    ! Should never happen! Prevents Inf distances
@@ -111,7 +111,10 @@ contains
       end if
 
       ! Check for void
-      if( p % matIdx() == VOID_MAT) cycle DTLoop
+      if(p % matIdx() == VOID_MAT) then
+        call tally % reportInColl(p, .true.)
+        cycle DTLoop
+      end if
 
       ! Give error if the particle somehow ended in an undefined material
       if (p % matIdx() == UNDEF_MAT) then
@@ -123,8 +126,12 @@ contains
       sigmaT = self % xsData % getTransMatXS(p, p % matIdx())
 
       ! Roll RNG to determine if the collision is real or virtual
-      ! Exit the loop if the collision is real
-      if (p % pRNG % get() < sigmaT*majorant_inv) exit DTLoop
+      ! Exit the loop if the collision is real, report collision if virtual
+      if (p % pRNG % get() < sigmaT*majorant_inv) then
+        exit DTLoop
+      else
+        call tally % reportInColl(p, .true.)
+      end if
 
     end do DTLoop
 

--- a/docs/User Manual.rst
+++ b/docs/User Manual.rst
@@ -869,6 +869,8 @@ The **tally clerks** determine which kind of estimator will be used. The options
     that defines the domains of integration of each tally
   - filter (*optional*): can filter out particles with certain properties,
     preventing them from scoring results
+  - handleVirtual (*optional*, default = 0): if set to 1, delta tracking virtual collisions
+    are tallied with a collisionClerk as well as physical collisions
 
 * trackClerk
 


### PR DESCRIPTION
It seems that both collisionclerk and transportoperatorDT have to know about virtual collisions wanting to be handled to 1) use majorant XS for scoring flux and 2) reporting both physical and virtual collisions (but avoid actually colliding when particle located in void). This is done by setting flag in collisionclerk based on input and communicating this throught tallyadmin to transportoperatorDT.

Virtual collisions can be handled by setting handleVirtual 1; in the input file:
tally  {
  collision_estimator { 
  type collisionClerk; response (flux); flux { type fluxResponse; }
  map {type energyMap; grid lin; min 0.0; max 14.1; N 70;}
  handleVirtual 1;
  }
}

Only values 1 or 0 allowed, 0 by default.
 