### PR TITLE
Fix the Read The Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,10 +1,14 @@
 
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 sphinx:
   configuration: docs/conf.py
 
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements-rtd.txt

--- a/docs/requirements-rtd.txt
+++ b/docs/requirements-rtd.txt
@@ -1,1 +1,2 @@
 sphinxcontrib-katex
+sphinx-rtd-theme


### PR DESCRIPTION
The configuration yaml file of the SCONE webpage was not up to date. As the result since the end of September the builds of the documentation for the website (https://scone.readthedocs.io/en/latest/) were failing and the changes in the documentation were not being published online. 

This PR fixes it. I have tested that it works by creating another branch in the repository. I see no reason not to merge it immediately. 