### PR TITLE
User defined colours for plotting materials

### DIFF
--- a/InputFiles/c5g7_mox
+++ b/InputFiles/c5g7_mox
@@ -106,6 +106,7 @@ viz {
     centre (0.0 0.0 0.0);
     //width (25.0 25.0);
     axis z;
+    offset -17;
     res (500 500);
   }
 }
@@ -119,6 +120,7 @@ nuclearData {
 
     water {
       temp 75675;
+      rgb (0 0 139); // Colour of water is dark blue
       moder { 1001.03 h-h2o.42; }
       composition {
       1001.03    6.700E-002;

--- a/NuclearData/materialMenu_mod.f90
+++ b/NuclearData/materialMenu_mod.f90
@@ -1,9 +1,9 @@
 !!
-!! Material Menu is a module (Singleton) that contains global definitions of diffrent materials
+!! Material Menu is a module (Singleton) that contains global definitions of different materials
 !!
 !! It exists to make it easier for all databases to refer to the same materials by the same
-!! name and index. This is necessary to avoid confusion resulting from diffrent materials with the
-!! same name or index in diffrent databases.
+!! name and index. This is necessary to avoid confusion resulting from different materials with the
+!! same name or index in different databases.
 !!
 !! Public Members:
 !!   materialDefs -> array of material definitions of type materialItem
@@ -36,9 +36,9 @@ module materialMenu_mod
   !! Information about a single nuclide
   !!
   !! Based somewhat on MCNP conventions.
-  !! Atomic and Mass number identify cleary a nuclide species
+  !! Atomic and Mass number identify clearly a nuclide species
   !! Evaluation number T allows to refer to multiple states/evaluations of the same nuclide species
-  !! E.G. at a Diffrent temperature as in MCNP Library.
+  !! E.G. at a Different temperature as in MCNP Library.
   !!
   !! Public members:
   !!   Z -> Atomic number
@@ -142,7 +142,7 @@ contains
     integer(shortInt)                           :: i
     character(nameLen)                          :: temp
 
-    ! Clean whatever may be alrady present
+    ! Clean whatever may be already present
     call kill()
 
     ! Load all material names
@@ -218,7 +218,7 @@ contains
   !! Result:
   !!   nameLen long character with material name
   !!
-  !! Erorrs:
+  !! Error:
   !!   If idx is -ve or larger then number of defined materials
   !!   Empty string '' is returned as its name
   !!
@@ -422,7 +422,7 @@ contains
     za = verify(key(1:L),'0123456789')
     tt = verify(key(1:L),'0123456789', back = .true.)
 
-    ! Verify that the location of the dot is consistant
+    ! Verify that the location of the dot is consistent
     isIt = dot == za .and. dot == tt
 
   end function isNucDefinition
@@ -467,7 +467,7 @@ contains
   !!   None
   !!
   !! Result:
-  !!   Character in format ZZAAA.TT that dscribes nuclide definition
+  !!   Character in format ZZAAA.TT that describes nuclide definition
   !!
   !! Errors:
   !!   None
@@ -491,17 +491,17 @@ contains
   !! Get pointer to a material definition under matIdx
   !!
   !! Args:
-  !!   matIdx [in] -> Index of the material
+  !!   idx [in] -> Index of the material
   !!
   !! Result:
   !!   Pointer to a materialItem with the definition
   !!
   !! Errors:
-  !!   FatalError if matIdx does not correspond to any defined material
+  !!   FatalError if idx does not correspond to any defined material
   !!   FatalError if material definitions were not loaded
   !!
-  function getMatPtr(matIdx) result(ptr)
-    integer(shortInt), intent(in) :: matIdx
+  function getMatPtr(idx) result(ptr)
+    integer(shortInt), intent(in) :: idx
     type(materialItem), pointer   :: ptr
     character(100), parameter :: Here = 'getMatPtr (materialMenu_mod.f90)'
 
@@ -511,13 +511,13 @@ contains
     end if
 
     ! Verify matIdx
-    if( matIdx <= 0 .or. matIdx > nMat()) then
-      call fatalError(Here,"matIdx: "//numToChar(matIdx)// &
+    if( idx <= 0 .or. idx > nMat()) then
+      call fatalError(Here,"matIdx: "//numToChar(idx)// &
                            " does not correspond to any defined material")
     end if
 
     ! Attach pointer
-    ptr => materialDefs(matIdx)
+    ptr => materialDefs(idx)
 
   end function getMatPtr
 

--- a/SharedModules/CMakeLists.txt
+++ b/SharedModules/CMakeLists.txt
@@ -12,7 +12,8 @@ add_sources( ./genericProcedures.f90
              ./timer_mod.f90
              ./charLib_func.f90
              ./openmp_func.f90
-             ./errors_mod.f90)
+             ./errors_mod.f90
+             ./colours_func.f90)
 
 add_unit_tests( ./Tests/grid_test.f90
                 ./Tests/energyGrid_test.f90
@@ -21,4 +22,5 @@ add_unit_tests( ./Tests/grid_test.f90
                 ./Tests/hashFunctions_test.f90
                 ./Tests/timer_test.f90
                 ./Tests/conversions_test.f90
-                ./Tests/charLib_test.f90)
+                ./Tests/charLib_test.f90
+                ./Tests/colours_test.f90)

--- a/SharedModules/Tests/colours_test.f90
+++ b/SharedModules/Tests/colours_test.f90
@@ -1,0 +1,26 @@
+module colours_test
+  use numPrecision
+  use colours_func, only : rgb24bit
+  use pFUnit_mod
+
+  implicit none
+
+contains
+
+
+@Test
+  subroutine testColourConversions()
+
+    ! Test by comparison with some hex values
+    @assertEqual(int(z"123456"), rgb24bit(18, 52, 86))
+
+    @assertEqual(int(z"000000"), rgb24bit(0, 0, 0))
+    @assertEqual(int(z"ffffff"), rgb24bit(255, 255, 255))
+
+    @assertEqual(int(z"ff0000"), rgb24bit(255, 0, 0))
+    @assertEqual(int(z"00ff00"), rgb24bit(0, 255, 0))
+    @assertEqual(int(z"0000ff"), rgb24bit(0, 0, 255))
+
+  end subroutine testColourConversions
+
+end module colours_test

--- a/SharedModules/colours_func.f90
+++ b/SharedModules/colours_func.f90
@@ -1,0 +1,48 @@
+!!
+!! Contains function to deal with colours
+!!
+module colours_func
+  use numPrecision
+  use genericProcedures, only: numToChar
+  use errors_mod,        only: fatalError
+  implicit none
+
+  public :: rgb24bit
+
+contains
+
+
+  !!
+  !! Return integer with 24bit colour value from r,g,b components
+  !!
+  !! Args:
+  !!   r [in] -> red component in [0-255] range
+  !!   g [in] -> green component in [0-255] range
+  !!   b [in] -> blue component in [0-255] range
+  !!
+  function rgb24bit(r, g, b) result(col)
+    integer(shortInt), intent(in) :: r
+    integer(shortInt), intent(in) :: g
+    integer(shortInt), intent(in) :: b
+    integer(shortInt)             :: col
+    character(100), parameter :: Here = "rgb24bit (colours_func.f90)"
+
+    ! Check that the values are in the correct range
+    if (r < 0 .or. r > 255) then
+      call fatalError(Here, "Red value is out of [0-255] range: " // numToChar(r))
+    end if
+    if (g < 0 .or. g > 255) then
+      call fatalError(Here, "Green value is out of [0-255] range: " // numToChar(g))
+    end if
+    if (b < 0 .or. b > 255) then
+      call fatalError(Here, "Blue value is out of [0-255] range: " // numToChar(b))
+    end if
+
+    ! Compute the 24 bit colour
+    ! Note inversion, blue is the least significant bits
+    col = b + 256 * g + 256 * 256 * r
+
+  end function rgb24bit
+
+
+end module colours_func

--- a/Visualisation/visualiser_class.f90
+++ b/Visualisation/visualiser_class.f90
@@ -8,6 +8,7 @@ module visualiser_class
   use commandLineUI,      only : getInputFile
   use dictionary_class,   only : dictionary
   use geometry_inter,     only : geometry
+  use materialMenu_mod,   only : mm_colourMap => colourMap
   use outputVTK_class
 
   implicit none
@@ -353,24 +354,10 @@ contains
     integer(shortInt), intent(in) :: matIdx
     integer(shortInt)             :: colour
     integer(shortInt), intent(in) :: offset
-    integer(shortInt), parameter :: COL_OUTSIDE = int(z'ffffff', shortInt)
-    integer(shortInt), parameter :: COL_VOID    = int(z'000000', shortInt)
-    integer(shortInt), parameter :: COL_UNDEF   = int(z'00ff00', shortInt)
 
-    select case (matIdx)
-      case (OUTSIDE_MAT)
-        colour = COL_OUTSIDE
-
-      case (VOID_MAT)
-        colour = COL_VOID
-
-      case (UNDEF_MAT)
-        colour = COL_UNDEF
-
-      case default
-        colour = knuthHash(matIdx + offset, 24)
-
-    end select
+    ! Since Knuth hash is cheap we can compute it anyway even if colour from
+    ! the map will end up being used
+    colour = mm_colourMap % getOrDefault(matIdx, knuthHash(matIdx + offset, 24))
 
   end function materialColour
 

--- a/Visualisation/visualiser_class.f90
+++ b/Visualisation/visualiser_class.f90
@@ -3,7 +3,7 @@ module visualiser_class
   use numPrecision
   use universalVariables
   use genericProcedures,  only : fatalError, numToChar
-  use hashFunctions_func, only : knuthHash
+  use hashFunctions_func, only : knuthHash, FNV_1
   use imgBmp_func,        only : imgBmp_toFile
   use commandLineUI,      only : getInputFile
   use dictionary_class,   only : dictionary
@@ -232,7 +232,9 @@ contains
     real(defReal), dimension(:), allocatable       :: temp
     integer(shortInt), dimension(:), allocatable   :: tempInt
     integer(shortInt), dimension(:,:), allocatable :: img
-    integer(shortInt)                              :: offset = 0
+    integer(shortInt)                              :: offset
+    character(10)                                  :: time
+    character(8)                                   :: date
     character(100), parameter :: Here = 'makeBmpImg (visualiser_class.f90)'
 
     ! Get plot parameters
@@ -290,7 +292,15 @@ contains
     end if
 
     ! Colourmap offset
-    call dict % getOrDefault(offset, 'offset', 0)
+    ! If not given select randomly
+    if (dict % isPresent('offset')) then
+      call dict % get(offset, 'offset')
+
+    else
+      call date_and_time(date, time)
+      call FNV_1(date // time, offset)
+
+    end if
 
     ! Get plot
     if (useWidth) then

--- a/Visualisation/visualiser_class.f90
+++ b/Visualisation/visualiser_class.f90
@@ -18,7 +18,7 @@ module visualiser_class
   !!
   !! Object that creates images relating to SCONE geometries
   !! Should be extensible for adding different visualisation methods
-  !! Recieves and generates data for visualisation
+  !! Receives and generates data for visualisation
   !! Requires a dictionary input which specifies the procedures to call
   !! Presently supports: VTK voxel mesh creation
   !!
@@ -59,7 +59,7 @@ contains
   !! Initialises visualiser
   !!
   !! Provides visualiser with filename for output,
-  !! geometry information, and the dictionary decribing
+  !! geometry information, and the dictionary describing
   !! what is to be plotted
   !!
   !! Args:
@@ -148,7 +148,7 @@ contains
   !!   }
   !!
   !! TODO: VTK output is placed in a input filename appended by '.vtk' extension.
-  !!   This prevents multiple VTK visualistions (due to overriding). Might also become
+  !!   This prevents multiple VTK visualisations (due to overriding). Might also become
   !!   weird for input files with extension e.g. 'input.dat'.
   !!   DEMAND USER TO GIVE OUTPUT NAME
   !!
@@ -216,7 +216,7 @@ contains
   !!   }
   !!
   !! NOTE: If 'width' is not given, the plot will extend to the bounds of the geometry.
-  !!   This may result in the provided centre beeing moved to the center of the geoemtry in the
+  !!   This may result in the provided centre being moved to the center of the geometry in the
   !!   plot plane. However, the position on the plot axis will be unchanged.
   !!
   subroutine makeBmpImg(self, dict)
@@ -301,10 +301,10 @@ contains
     ! Translate to an image
     select case (what)
       case ('material')
-        img = materialColor(img, offset)
+        img = materialColour(img, offset)
 
       case ('uniqueID')
-        img = uniqueIDColor(img)
+        img = uniqueIDColour(img)
 
       case default
         call fatalError(Here, "Invalid request for plot target. Must be 'material' or 'uniqueID'&
@@ -335,9 +335,9 @@ contains
 
 
   !!
-  !! Convert matIdx to a 24bit color
+  !! Convert matIdx to a 24bit colour
   !!
-  !! Special materials are associeted with special colors:
+  !! Special materials are associated with special colours:
   !!   OUTSIDE_MAT -> white (#ffffff)
   !!   VOID_MAT    -> black (#000000)
   !!   UNDEF_MAT   -> green (#00ff00)
@@ -347,11 +347,11 @@ contains
   !!   offset [in] -> Offset to be used in the hash function
   !!
   !! Result:
-  !!   A 24-bit color specifing the material
+  !!   A 24-bit colour specifying the material
   !!
-  elemental function materialColor(matIdx, offset) result(color)
+  elemental function materialColour(matIdx, offset) result(colour)
     integer(shortInt), intent(in) :: matIdx
-    integer(shortInt)             :: color
+    integer(shortInt)             :: colour
     integer(shortInt), intent(in) :: offset
     integer(shortInt), parameter :: COL_OUTSIDE = int(z'ffffff', shortInt)
     integer(shortInt), parameter :: COL_VOID    = int(z'000000', shortInt)
@@ -359,43 +359,43 @@ contains
 
     select case (matIdx)
       case (OUTSIDE_MAT)
-        color = COL_OUTSIDE
+        colour = COL_OUTSIDE
 
       case (VOID_MAT)
-        color = COL_VOID
+        colour = COL_VOID
 
       case (UNDEF_MAT)
-        color = COL_UNDEF
+        colour = COL_UNDEF
 
       case default
-        color = knuthHash(matIdx + offset, 24)
+        colour = knuthHash(matIdx + offset, 24)
 
     end select
 
-  end function materialColor
+  end function materialColour
 
   !!
-  !! Convert uniqueID to 24bit color
+  !! Convert uniqueID to 24bit colour
   !!
   !! An elemental wrapper over Knuth Hash
   !!
-  !! We use a hash function to scatter colors accross all available.
+  !! We use a hash function to scatter colours across all available.
   !! Knuth multiplicative hash is very good at scattering integer
-  !! sequences e.g. {1, 2, 3...}. Thus, it is ideal for a colormap.
+  !! sequences e.g. {1, 2, 3...}. Thus, it is ideal for a colourmap.
   !!
   !! Args:
   !!   uniqueID [in] -> Value of the uniqueID
   !!
   !! Result:
-  !!   A 24-bit color specifing the uniqueID
+  !!   A 24-bit colour specifying the uniqueID
   !!
-  elemental function uniqueIDColor(uniqueID) result(color)
+  elemental function uniqueIDColour(uniqueID) result(colour)
     integer(shortInt), intent(in) :: uniqueID
-    integer(shortInt)             :: color
+    integer(shortInt)             :: colour
 
-    color = knuthHash(uniqueID, 24)
+    colour = knuthHash(uniqueID, 24)
 
-  end function uniqueIDColor
+  end function uniqueIDColour
 
 
 end module visualiser_class

--- a/Visualisation/visualiser_class.f90
+++ b/Visualisation/visualiser_class.f90
@@ -250,7 +250,7 @@ contains
     call dict % get(temp, 'centre')
 
     if (size(temp) /= 3) then
-      call fatalError(Here, "'center' must have size 3. Has: "//numToChar(size(temp)))
+      call fatalError(Here, "'centre' must have size 3. Has: "//numToChar(size(temp)))
     end if
 
     centre = temp

--- a/Visualisation/visualiser_class.f90
+++ b/Visualisation/visualiser_class.f90
@@ -211,6 +211,7 @@ contains
   !!     centre (0.0 0.0 0.0); // Coordinates of the centre of the plot
   !!     axis x;               // Must be 'x', 'y' or 'z'
   !!     res (300 300);        // Resolution of the image
+  !!     #offset 978; #        // Parameter to 'randomize' the colour map
   !!     #width (1.0 2.0);#    // Width of the plot from the centre
   !!   }
   !!
@@ -230,6 +231,7 @@ contains
     real(defReal), dimension(:), allocatable       :: temp
     integer(shortInt), dimension(:), allocatable   :: tempInt
     integer(shortInt), dimension(:,:), allocatable :: img
+    integer(shortInt)                              :: offset = 0
     character(100), parameter :: Here = 'makeBmpImg (visualiser_class.f90)'
 
     ! Get plot parameters
@@ -286,6 +288,9 @@ contains
 
     end if
 
+    ! Colourmap offset
+    call dict % getOrDefault(offset, 'offset', 0)
+
     ! Get plot
     if (useWidth) then
       call self % geom % slicePlot(img, centre, dir, what, width)
@@ -296,7 +301,7 @@ contains
     ! Translate to an image
     select case (what)
       case ('material')
-        img = materialColor(img)
+        img = materialColor(img, offset)
 
       case ('uniqueID')
         img = uniqueIDColor(img)
@@ -339,13 +344,15 @@ contains
   !!
   !! Args:
   !!   matIdx [in] -> Value of the material index
+  !!   offset [in] -> Offset to be used in the hash function
   !!
   !! Result:
   !!   A 24-bit color specifing the material
   !!
-  elemental function materialColor(matIdx) result(color)
+  elemental function materialColor(matIdx, offset) result(color)
     integer(shortInt), intent(in) :: matIdx
     integer(shortInt)             :: color
+    integer(shortInt), intent(in) :: offset
     integer(shortInt), parameter :: COL_OUTSIDE = int(z'ffffff', shortInt)
     integer(shortInt), parameter :: COL_VOID    = int(z'000000', shortInt)
     integer(shortInt), parameter :: COL_UNDEF   = int(z'00ff00', shortInt)
@@ -361,7 +368,7 @@ contains
         color = COL_UNDEF
 
       case default
-        color = knuthHash(matIdx, 24)
+        color = knuthHash(matIdx + offset, 24)
 
     end select
 

--- a/docs/User Manual.rst
+++ b/docs/User Manual.rst
@@ -275,9 +275,9 @@ neutronCEstd, to perform analog collision processing
   target nuclide movement. Target movement is sampled if target mass A < massThreshold. [Mn]
 * DBRCeMin (*optional*, default = 1.0e-08): minimum DBRC energy. [MeV]
 * DBRCeMax (*optional*, default = 2.0e-04): maximum DBRC energy. [MeV]
-  
+
 Example: ::
-  
+
       collisionOperator { neutronCE { type neutronCEstd; minEnergy 1.0e-12; maxEnergy 30.0;
       energyThreshold 200; massThreshold 2; DBRCeMin 1.0e-06; DBRCeMax 0.001; } }
 
@@ -679,6 +679,9 @@ bmp
 * what (*optional*, default = material): defines what is highlighted in the
   plot; options are ``material`` and ``uniqueID``, where ``uniqueID``
   highlights unique cell IDs
+* offset (*optional*, default = 0) An integer (positive or negative) that
+  shifts the sequence of colours assigned to materials. Allows to change colours
+  from the default sequence in parametric way.
 
 Example: ::
 
@@ -725,7 +728,7 @@ from ACE files.
   resonance probability tables treatment
 * DBRC (*optional*, default = no DBRC): list of ZAIDs of nuclides for which DBRC has
   to be applied.
-  
+
 Example: ::
 
       ceData { type aceNuclearDatabase; aceLibrary ./myFolder/ACElib/JEF311.aceXS;
@@ -734,7 +737,7 @@ Example: ::
 .. note::
    If DBRC is applied, the 0K cross section ace files of the relevant nuclides must
    be included in the aceLibrary file.
-      
+
 baseMgNeutronDatabase
 #####################
 
@@ -790,6 +793,9 @@ Other options are:
 * xsFile: needed for multi-group simulations. Must contain the path to the file where
   the multi-group cross sections are stored.
 
+* rgb (*optional*): An array of three integers specifying the RGB colour e.g. ``(255 0 0)``. The
+  colour defined in this way will be used for visualisation of the material in the geometry plots.
+
 Example 1: ::
 
       materials {
@@ -800,6 +806,7 @@ Example 1: ::
       8016.03    0.018535464; }
       }
       water { temp 273;
+      rgb (0 0 200);
       composition {
       1001.03   0.0222222;
       8016.03   0.00535; }
@@ -1073,7 +1080,7 @@ Example: ::
       }
       }
 
-.. note:: 
+.. note::
    To calculate the average weight, one should divide weight moment 1 (weight1)
    by weight moment 0 (weight0). To calculate the variance of the weights, the
    tally results have to be post-processed as: var = weight2/weight0 - (weight1/weight0)^2

--- a/docs/User Manual.rst
+++ b/docs/User Manual.rst
@@ -679,9 +679,9 @@ bmp
 * what (*optional*, default = material): defines what is highlighted in the
   plot; options are ``material`` and ``uniqueID``, where ``uniqueID``
   highlights unique cell IDs
-* offset (*optional*, default = 0) An integer (positive or negative) that
+* offset (*optional*, default = random) An integer (positive or negative) that
   shifts the sequence of colours assigned to materials. Allows to change colours
-  from the default sequence in parametric way.
+  from the default sequence in a parametric way.
 
 Example: ::
 


### PR DESCRIPTION
Resolves #80. 
Makes the following changes: 
- Adds `offset` option to BMP output that allows to "shift" the colour sequence by some +ve or -ve integer. Thus change the colours in the image 
- Materials can now take optional `rgb` entry which specifies the colour which will be used to print them. e.g. `rgb (255 0 0)`. 
- Minor stylistic and grammatical changes  
- Update to the user manual and `c5g7_mox` example input file to showcase new features 
