### PR TITLE
Fix related to previous varRed PR

### DIFF
--- a/ParticleObjects/particle_class.f90
+++ b/ParticleObjects/particle_class.f90
@@ -274,6 +274,7 @@ contains
     LHS % type                  = RHS % type
     LHS % time                  = RHS % time
     LHS % collisionN            = RHS % collisionN
+    LHS & splitCount            = 0 ! Reinitialise counter for number of splits
 
   end subroutine particle_fromParticleState
 

--- a/ParticleObjects/particle_class.f90
+++ b/ParticleObjects/particle_class.f90
@@ -274,7 +274,7 @@ contains
     LHS % type                  = RHS % type
     LHS % time                  = RHS % time
     LHS % collisionN            = RHS % collisionN
-    LHS & splitCount            = 0 ! Reinitialise counter for number of splits
+    LHS % splitCount            = 0 ! Reinitialise counter for number of splits
 
   end subroutine particle_fromParticleState
 


### PR DESCRIPTION
After removing the property splitCount from the particleState, the behavior when detaining a particleState was undefined. 

This way, every time a particle state is detained, the counter is reinitialised. 