### PR TITLE
OpenMP reproducibility

### DIFF
--- a/ParticleObjects/Source/source_inter.f90
+++ b/ParticleObjects/Source/source_inter.f90
@@ -110,15 +110,13 @@ contains
       ! Generate n particles to populate dungeon
       ! TODO: advance the rand after source generation!
       !       This should prevent reusing RNs during transport
-      !$omp parallel
-      pRand = rand
-      !$omp do
+      !$omp parallel do
       do i = 1, n
+        pRand = rand
         call pRand % stride(i)
         call dungeon % replace(self % sampleParticle(pRand), i)
       end do
-      !$omp end do
-      !$omp end parallel
+      !$omp end parallel do
 
     end subroutine generate
 

--- a/ParticleObjects/Tests/particleDungeon_test.f90
+++ b/ParticleObjects/Tests/particleDungeon_test.f90
@@ -217,7 +217,7 @@ contains
     ! Store some particles with non-uniform weight
     do i = 1,10
       p % w = 0.5_defReal + i * 0.1_defReal
-      p % showerID = 1       ! Avoid triggering error on sort by showerID
+      p % broodID = 1       ! Avoid triggering error on sort by broodID
       call dungeon % detain(p)
     end do
 
@@ -255,7 +255,7 @@ contains
     ! Store some particles with non-uniform weight
     do i = 1,10
       p % w = 0.5_defReal + i * 0.1_defReal
-      p % showerID = 1       ! Avoid triggering error on sort by showerID
+      p % broodID = 1       ! Avoid triggering error on sort by broodID
       call dungeon % detain(p)
     end do
 
@@ -277,7 +277,7 @@ contains
   !! Test sorting of the population by shower ID without duplicates
   !!
 @Test
-  subroutine testSortingByShowerID()
+  subroutine testSortingByBroodID()
     type(particleDungeon)    :: dungeon
     type(particle)           :: p
     integer(shortInt)        :: i
@@ -288,27 +288,27 @@ contains
 
     ! Store some particles with shower ID in reverse order
     do i = 1,10
-      p % showerID = 10 - i + 1
+      p % broodID = 10 - i + 1
       call dungeon % detain(p)
     end do
 
     ! Sort by shower ID
-    call dungeon % sortByShowerId(10)
+    call dungeon % sortByBroodID(10)
 
     ! Verify order
     do i = 1,10
       call dungeon % copy(p, i)
-      @assertEqual(i, p % showerID)
+      @assertEqual(i, p % broodID)
     end do
 
-  end subroutine testSortingByShowerID
+  end subroutine testSortingByBroodID
 
 
   !!
   !! Test sorting of the population by shower ID with duplicates
   !!
   @Test
-  subroutine testSortingByShowerID_withDuplicates()
+  subroutine testSortingByBroodID_withDuplicates()
     type(particleDungeon)    :: dungeon
     type(particle)           :: p
     integer(shortInt)        :: i, j
@@ -323,25 +323,25 @@ contains
     ! that the insertion order is preserved (for particles with the same shower ID)
     do j = 1,N_duplicates
       do i = 1,10
-        p % showerID = 10 - i + 1
+        p % broodID = 10 - i + 1
         p % G = j
         call dungeon % detain(p)
       end do
     end do
 
     ! Sort by shower ID
-    call dungeon % sortByShowerId(10)
+    call dungeon % sortByBroodID(10)
 
     ! Verify order
     do i = 1,10
       do j = 1, N_duplicates
         call dungeon % copy(p, j + (i-1) * N_duplicates)
-        @assertEqual(i, p % showerID)
+        @assertEqual(i, p % broodID)
         @assertEqual(j, p % G)
       end do
     end do
 
-  end subroutine testSortingByShowerID_withDuplicates
+  end subroutine testSortingByBroodID_withDuplicates
 
 
 end module particleDungeon_test

--- a/ParticleObjects/Tests/particleDungeon_test.f90
+++ b/ParticleObjects/Tests/particleDungeon_test.f90
@@ -274,7 +274,7 @@ contains
   end subroutine testNormPopUp
 
   !!
-  !! Test sorting of the population by shower ID without duplicates
+  !! Test sorting of the population by brood ID without duplicates
   !!
 @Test
   subroutine testSortingByBroodID()
@@ -286,13 +286,13 @@ contains
     ! Initialise
     call dungeon % init(10)
 
-    ! Store some particles with shower ID in reverse order
+    ! Store some particles with brood ID in reverse order
     do i = 1,10
       p % broodID = 10 - i + 1
       call dungeon % detain(p)
     end do
 
-    ! Sort by shower ID
+    ! Sort by brood ID
     call dungeon % sortByBroodID(10)
 
     ! Verify order
@@ -305,7 +305,7 @@ contains
 
 
   !!
-  !! Test sorting of the population by shower ID with duplicates
+  !! Test sorting of the population by brood ID with duplicates
   !!
   @Test
   subroutine testSortingByBroodID_withDuplicates()
@@ -318,18 +318,18 @@ contains
     ! Initialise
     call dungeon % init(10 * N_duplicates)
 
-    ! Store some particles with shower ID in reverse order
+    ! Store some particles with brood ID in reverse order
     ! Use the group number to distinguish duplicates and make sure
-    ! that the insertion order is preserved (for particles with the same shower ID)
-    do j = 1,N_duplicates
-      do i = 1,10
+    ! that the insertion order is preserved (for particles with the same brood ID)
+    do j = 1, N_duplicates
+      do i = 1, 10
         p % broodID = 10 - i + 1
         p % G = j
         call dungeon % detain(p)
       end do
     end do
 
-    ! Sort by shower ID
+    ! Sort by brood ID
     call dungeon % sortByBroodID(10)
 
     ! Verify order

--- a/ParticleObjects/Tests/particleDungeon_test.f90
+++ b/ParticleObjects/Tests/particleDungeon_test.f90
@@ -279,7 +279,7 @@ contains
 @Test
   subroutine testSortingByBroodID()
     type(particleDungeon)    :: dungeon
-    type(particle)           :: p
+    type(particleState)      :: p
     integer(shortInt)        :: i
     real(defReal), parameter :: TOL = 1.0E-9
 
@@ -297,7 +297,7 @@ contains
 
     ! Verify order
     do i = 1,10
-      call dungeon % copy(p, i)
+      p = dungeon % get(i)
       @assertEqual(i, p % broodID)
     end do
 
@@ -310,7 +310,7 @@ contains
   @Test
   subroutine testSortingByBroodID_withDuplicates()
     type(particleDungeon)    :: dungeon
-    type(particle)           :: p
+    type(particleState)      :: p
     integer(shortInt)        :: i, j
     integer(shortInt), parameter :: N_duplicates = 7
     real(defReal), parameter :: TOL = 1.0E-9
@@ -335,7 +335,7 @@ contains
     ! Verify order
     do i = 1,10
       do j = 1, N_duplicates
-        call dungeon % copy(p, j + (i-1) * N_duplicates)
+        p = dungeon % get(j + (i-1) * N_duplicates)
         @assertEqual(i, p % broodID)
         @assertEqual(j, p % G)
       end do

--- a/ParticleObjects/particleDungeon_class.f90
+++ b/ParticleObjects/particleDungeon_class.f90
@@ -403,7 +403,7 @@ contains
     integer(shortInt), intent(in)         :: N
     class(RNG), intent(inout)             :: rand
     integer(shortInt)                     :: excessP, n_copies, n_duplicates
-    integer(shortInt)                     :: i, idx
+    integer(shortInt)                     :: i, idx, maxShowerID
     integer(shortInt), dimension(:), allocatable :: duplicates
     character(100), parameter :: Here =' normSize (particleDungeon_class.f90)'
 
@@ -415,7 +415,9 @@ contains
       call fatalError(Here,'Requested size: '//numToChar(N) //' is not +ve')
     end if
 
-    call self % sortByShowerID(N)
+    ! Determine the maximum shower ID and sort the dungeon
+    maxShowerID = maxval(self % prisoners(1:self % pop) % showerID)
+    call self % sortByShowerID(maxShowerID)
 
     ! Calculate excess particles to be removed
     excessP = self % pop - N
@@ -479,6 +481,9 @@ contains
     count = 0
     do i = 1, self % pop
       id = self % prisoners(i) % showerID
+
+      if (id < 1 .or. id > k) call fatalError(Here, 'Shower ID out of range: '//numToChar(id))
+
       count(id) = count(id) + 1
     end do
 

--- a/ParticleObjects/particleDungeon_class.f90
+++ b/ParticleObjects/particleDungeon_class.f90
@@ -326,8 +326,16 @@ contains
 
   !!
   !! Copy particle from a location inside the dungeon
-  !! Makes particle alive at exit
-  !! Gives fatalError if requested index is 0, -ve or above current population
+  !!
+  !! Makes particle alive at exit. Also sets the broodID of the particle
+  !! making it ready to be transported.
+  !!
+  !! Args:
+  !!  p   [inout] -> Particle to be filled with data
+  !!  idx [in]    -> Index of the particle to be copied
+  !!
+  !! Errors:
+  !!  fatalError if requested index is 0, -ve or above current population
   !!
   subroutine copy(self, p, idx)
     class(particleDungeon), intent(in) :: self
@@ -337,13 +345,14 @@ contains
 
     ! Protect against out-of-bounds access
     if( idx <= 0 .or. idx > self % pop ) then
-      call fatalError(Here,'Out of bounds acces with idx: '// numToChar(idx)// &
+      call fatalError(Here,'Out of bounds access with idx: '// numToChar(idx)// &
                            ' with particle population of: '// numToChar(self % pop))
     end if
 
     ! Load data into the particle
     p = self % prisoners(idx)
     p % isDead = .false.
+    p % broodID = idx
 
   end subroutine copy
 
@@ -610,10 +619,6 @@ contains
 
     ! Print out each particle co-ordinate
     do i = 1, self % pop
-      ! write(10,'(8A)') numToChar(self % prisoners(i) % r), &
-      !                  numToChar(self % prisoners(i) % dir), &
-      !                  numToChar(self % prisoners(i) % E), &
-      !                  numToChar(self % prisoners(i) % G)
       write(10, *) self % prisoners(i) % r, self % prisoners(i) % dir, &
                    self % prisoners(i) % E, self % prisoners(i) % G, &
                    self % prisoners(i) % broodID

--- a/ParticleObjects/particleDungeon_class.f90
+++ b/ParticleObjects/particleDungeon_class.f90
@@ -424,7 +424,7 @@ contains
       call fatalError(Here,'Requested size: '//numToChar(N) //' is not +ve')
     end if
 
-    ! Determine the maximum shower ID and sort the dungeon
+    ! Determine the maximum brood ID and sort the dungeon
     maxBroodID = maxval(self % prisoners(1:self % pop) % broodID)
     call self % sortByBroodID(maxbroodID)
 
@@ -472,10 +472,10 @@ contains
   end subroutine normSize
 
   !!
-  !! Reorder the dungeon so the shower ID is in the ascending order
+  !! Reorder the dungeon so the brood ID is in the ascending order
   !!
   !! Args:
-  !!   k [in] -> Maximum shower ID
+  !!   k [in] -> Maximum brood ID
   !!
   subroutine sortByBroodID(self, k)
     class(particleDungeon), intent(inout)        :: self
@@ -486,12 +486,12 @@ contains
     type(particleState)                          :: tmp
     character(100), parameter :: Here = 'sortBybroodID (particleDungeon_class.f90)'
 
-    ! Count number of particles with each shower ID
+    ! Count number of particles with each brood ID
     count = 0
     do i = 1, self % pop
       id = self % prisoners(i) % broodID
 
-      if (id < 1 .or. id > k) call fatalError(Here, 'Shower ID out of range: '//numToChar(id))
+      if (id < 1 .or. id > k) call fatalError(Here, 'Brood ID out of range: '//numToChar(id))
 
       count(id) = count(id) + 1
     end do

--- a/ParticleObjects/particleDungeon_class.f90
+++ b/ParticleObjects/particleDungeon_class.f90
@@ -91,7 +91,7 @@ module particleDungeon_class
     procedure  :: popWeight
     procedure  :: setSize
     procedure  :: printToFile
-    procedure :: sortByShowerID
+    procedure  :: sortByBroodID
 
     ! Private procedures
     procedure, private :: detain_particle
@@ -403,7 +403,7 @@ contains
     integer(shortInt), intent(in)         :: N
     class(RNG), intent(inout)             :: rand
     integer(shortInt)                     :: excessP, n_copies, n_duplicates
-    integer(shortInt)                     :: i, idx, maxShowerID
+    integer(shortInt)                     :: i, idx, maxBroodID
     integer(shortInt), dimension(:), allocatable :: duplicates
     character(100), parameter :: Here =' normSize (particleDungeon_class.f90)'
 
@@ -416,8 +416,8 @@ contains
     end if
 
     ! Determine the maximum shower ID and sort the dungeon
-    maxShowerID = maxval(self % prisoners(1:self % pop) % showerID)
-    call self % sortByShowerID(maxShowerID)
+    maxBroodID = maxval(self % prisoners(1:self % pop) % broodID)
+    call self % sortByBroodID(maxbroodID)
 
     ! Calculate excess particles to be removed
     excessP = self % pop - N
@@ -468,19 +468,19 @@ contains
   !! Args:
   !!   k [in] -> Maximum shower ID
   !!
-  subroutine sortByShowerID(self, k)
+  subroutine sortByBroodID(self, k)
     class(particleDungeon), intent(inout)        :: self
     integer(shortInt), intent(in)                :: k
     integer(shortInt), dimension(k)              :: count
     integer(shortInt)                            :: i, id, loc, c
     integer(shortInt), dimension(:), allocatable :: perm
     type(particleState)                          :: tmp
-    character(100), parameter :: Here = 'sortByShowerID (particleDungeon_class.f90)'
+    character(100), parameter :: Here = 'sortBybroodID (particleDungeon_class.f90)'
 
     ! Count number of particles with each shower ID
     count = 0
     do i = 1, self % pop
-      id = self % prisoners(i) % showerID
+      id = self % prisoners(i) % broodID
 
       if (id < 1 .or. id > k) call fatalError(Here, 'Shower ID out of range: '//numToChar(id))
 
@@ -498,7 +498,7 @@ contains
     ! Create the permutation array
     allocate(perm(self % pop))
     do i = 1, self % pop
-      id = self % prisoners(i) % showerID
+      id = self % prisoners(i) % broodID
       loc = count(id)
       count(id) = count(id) + 1
       perm(loc) = i
@@ -522,7 +522,7 @@ contains
 
     end do
 
-  end subroutine sortByShowerID
+  end subroutine sortByBroodID
 
 
   !!
@@ -616,7 +616,7 @@ contains
       !                  numToChar(self % prisoners(i) % G)
       write(10, *) self % prisoners(i) % r, self % prisoners(i) % dir, &
                    self % prisoners(i) % E, self % prisoners(i) % G, &
-                   self % prisoners(i) % showerID
+                   self % prisoners(i) % broodID
     end do
 
     ! Close the file

--- a/ParticleObjects/particle_class.f90
+++ b/ParticleObjects/particle_class.f90
@@ -56,6 +56,7 @@ module particle_class
     integer(shortInt)          :: cellIdx  = -1     ! Cell idx at the lowest coord level
     integer(shortInt)          :: uniqueID = -1     ! Unique id at the lowest coord level
     integer(shortInt)          :: collisionN = 0    ! Number of collisions
+    integer(shortInt)          :: showerID = 0      ! ID of the shower (source particle number)
   contains
     generic    :: assignment(=)  => fromParticle
     generic    :: operator(.eq.) => equal_particleState
@@ -111,6 +112,7 @@ module particle_class
     integer(shortInt)          :: fate = 0       ! Neutron's fate after being subjected to an operator
     integer(shortInt)          :: type           ! Particle type
     integer(shortInt)          :: collisionN = 0 ! Index of the number of collisions the particle went through
+    integer(shortInt)          :: showerID = 0   ! ID of the shower (source particle number)
 
     ! Particle processing information
     class(RNG), pointer        :: pRNG  => null()  ! Pointer to RNG associated with the particle
@@ -275,6 +277,7 @@ contains
     LHS % time                  = RHS % time
     LHS % collisionN            = RHS % collisionN
     LHS % splitCount            = 0 ! Reinitialise counter for number of splits
+    LHS % showerID              = RHS % showerID
 
   end subroutine particle_fromParticleState
 
@@ -618,6 +621,7 @@ contains
     LHS % uniqueID = RHS % coords % uniqueId
     LHS % cellIdx  = RHS % coords % cell()
     LHS % collisionN = RHS % collisionN
+    LHS % showerID = RHS % showerID
 
   end subroutine particleState_fromParticle
 
@@ -641,6 +645,7 @@ contains
     isEqual = isEqual .and. LHS % cellIdx  == RHS % cellIdx
     isEqual = isEqual .and. LHS % uniqueID == RHS % uniqueID
     isEqual = isEqual .and. LHS % collisionN == RHS % collisionN
+    isEqual = isEqual .and. LHS % showerID == RHS % showerID
 
     if( LHS % isMG ) then
       isEqual = isEqual .and. LHS % G == RHS % G
@@ -648,31 +653,6 @@ contains
       isEqual = isEqual .and. LHS % E == RHS % E
     end if
   end function equal_particleState
-
-!  !!
-!  !! Copy particle state into archive object
-!  !!
-!  subroutine particleState_fromParticle(LHS,RHS)
-!    class(particleState), intent(out) :: LHS
-!    class(particle), intent(in)       :: RHS
-!
-!    ! Call superclass procedure
-!    call phaseCoord_fromParticle(LHS,RHS)
-!
-!  end subroutine particleState_fromParticle
-
-!  !!
-!  !! Extend equality definition to particle state
-!  !!
-!  function equal_particleState(LHS,RHS) result(isEqual)
-!    class(particleState), intent(in) :: LHS
-!    type(particleState), intent(in)  :: RHS
-!    logical(defBool)                 :: isEqual
-!
-!    ! Call superclass procedure
-!    isEqual = equal_phaseCoord(LHS,RHS)
-!
-!  end function equal_particleState
 
   !!
   !! Prints state of the phaseCoord
@@ -708,6 +688,7 @@ contains
     self % cellIdx  = -1
     self % uniqueID = -1
     self % collisionN = 0
+    self % showerID = 0
 
   end subroutine kill_particleState
 

--- a/ParticleObjects/particle_class.f90
+++ b/ParticleObjects/particle_class.f90
@@ -103,7 +103,7 @@ module particle_class
     integer(shortInt)          :: fate = 0       ! Neutron's fate after being subjected to an operator
     integer(shortInt)          :: type           ! Particle type
     integer(shortInt)          :: collisionN = 0 ! Index of the number of collisions the particle went through
-    integer(shortInt)          :: broodID = 0    ! ID of the shower (source particle number)
+    integer(shortInt)          :: broodID = 0    ! ID of the brood (source particle number)
 
     ! Particle processing information
     class(RNG), pointer        :: pRNG  => null()  ! Pointer to RNG associated with the particle

--- a/PhysicsPackages/eigenPhysicsPackage_class.f90
+++ b/PhysicsPackages/eigenPhysicsPackage_class.f90
@@ -206,7 +206,7 @@ contains
           ! Save state
           call neutron % savePreHistory()
 
-          ! Transport particle untill its death
+          ! Transport particle until its death
           history: do
             call transOp % transport(neutron, tally, buffer, self % nextCycle)
             if(neutron % isDead) exit history
@@ -241,7 +241,7 @@ contains
       end if
 
       ! Normalise population
-      call self % nextCycle % normSize(self % pop, pRNG)
+      call self % nextCycle % normSize(self % pop, self % pRNG)
 
       if(self % printSource == 1) then
         call self % nextCycle % printToFile(trim(self % outputFile)//'_source'//numToChar(i))
@@ -310,7 +310,7 @@ contains
     call self % thisCycle % init(3 * self % pop)
     call self % nextCycle % init(3 * self % pop)
 
-    ! Generate initial surce
+    ! Generate initial source
     print *, "GENERATING INITIAL FISSION SOURCE"
     call self % initSource % generate(self % thisCycle, self % pop, self % pRNG)
     print *, "DONE!"
@@ -409,7 +409,7 @@ contains
     call dict % getOrDefault(self % outputFile,'outputFile','./output')
 
     ! Get output format and verify
-    ! Initialise output file before calculation (so mistake in format will be cought early)
+    ! Initialise output file before calculation (so mistake in format will be caught early)
     call dict % getOrDefault(self % outputFormat, 'outputFormat', 'asciiMATLAB')
     call test_out % init(self % outputFormat)
 

--- a/PhysicsPackages/eigenPhysicsPackage_class.f90
+++ b/PhysicsPackages/eigenPhysicsPackage_class.f90
@@ -195,6 +195,8 @@ contains
         ! Obtain particle current cycle dungeon
         call self % thisCycle % copy(neutron, n)
 
+        neutron % showerID = n
+
         bufferLoop: do
           call self % geom % placeCoord(neutron % coords)
 

--- a/PhysicsPackages/eigenPhysicsPackage_class.f90
+++ b/PhysicsPackages/eigenPhysicsPackage_class.f90
@@ -195,7 +195,7 @@ contains
         ! Obtain particle current cycle dungeon
         call self % thisCycle % copy(neutron, n)
 
-        neutron % showerID = n
+        neutron % broodID = n
 
         bufferLoop: do
           call self % geom % placeCoord(neutron % coords)

--- a/PhysicsPackages/eigenPhysicsPackage_class.f90
+++ b/PhysicsPackages/eigenPhysicsPackage_class.f90
@@ -195,8 +195,6 @@ contains
         ! Obtain particle current cycle dungeon
         call self % thisCycle % copy(neutron, n)
 
-        neutron % broodID = n
-
         bufferLoop: do
           call self % geom % placeCoord(neutron % coords)
 

--- a/PhysicsPackages/fixedSourcePhysicsPackage_class.f90
+++ b/PhysicsPackages/fixedSourcePhysicsPackage_class.f90
@@ -181,7 +181,6 @@ contains
 
         ! Obtain particle from dungeon
         call self % thisCycle % copy(p, n)
-        p % broodID = n
 
         bufferLoop: do
 

--- a/PhysicsPackages/fixedSourcePhysicsPackage_class.f90
+++ b/PhysicsPackages/fixedSourcePhysicsPackage_class.f90
@@ -181,6 +181,7 @@ contains
 
         ! Obtain particle from dungeon
         call self % thisCycle % copy(p, n)
+        p % showerID = n
 
         bufferLoop: do
 

--- a/PhysicsPackages/fixedSourcePhysicsPackage_class.f90
+++ b/PhysicsPackages/fixedSourcePhysicsPackage_class.f90
@@ -181,7 +181,7 @@ contains
 
         ! Obtain particle from dungeon
         call self % thisCycle % copy(p, n)
-        p % showerID = n
+        p % broodID = n
 
         bufferLoop: do
 

--- a/docs/User Manual.rst
+++ b/docs/User Manual.rst
@@ -86,6 +86,10 @@ fixedSourcePhysicsPackage, used for fixed source calculations
   stored in a thread-private buffer, after which particles are shifted to
   the common buffer
 
+.. note::
+  If the common buffer is used, the calculation will not be reproducible if it
+  is performed in parallel. This issue may be addressed in the future.
+
 Example: ::
 
         type fixedSourcePhysicsPackage;


### PR DESCRIPTION
First of all I think this one still requires a bit of work and more testing. I verified that things work on my laptop, but I haven't properly studied the impact on scaling. 

Basically this PR makes the parallel calculations with OpenMP reproducible. The following main changes were required: 
- `source_inter` sampling procedure had to be modified to skip from the initial RNG state (not the current thread-private). I'm afraid this bug avoided death in PR before...
- The incorrect, thread-private, RNG was used for sampling of the renormalisation of the source 
- The `particleDungeon` sorting has been implemented based on the `showerID` which is basically the sequence in this cycle dungeon of the particle. I am not happy with the name but I couldn't figure out a better one! (Also addresses #52) 
  - The sorting is done with some extra memory allocated at each cycle to store the permutation and count arrays. 
  - The permutation is done in place to conserve memory requirements (but it makes parallelisation not possible :-/, I am not sure it was a correct decision) 
  - Generally the sorting and renormalisation of the `particleDungeon` are done in serial and I fear a bit about scalability as a result of it.    
  
  P.S. Also I realised now that I forgot to add extra tests :-/ Treat it like a draft for now, please. 