### PR TITLE
Update .gitignore to ignore build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ __pycache__/
 cream.egg-info/
 *.pyc
 
+# Ignore build folder
+Build
+build
+
 # Ignore all hidden files (except gitignore)
 .*
 !/.gitignore


### PR DESCRIPTION
As for Esmae's suggestion, this PR is listing the build folder in .gitignore so that it's not tracked, to prevent accidents.