### PR TITLE
Changing velocity to speed

### DIFF
--- a/ParticleObjects/Tests/particle_test.f90
+++ b/ParticleObjects/Tests/particle_test.f90
@@ -248,8 +248,8 @@ contains
     @assertEqual(3, cellIdx, 'Cell Index. Level 1.')
     @assertEqual(1, uniIdx, 'Universe Index. Level 1.')
 
-    ! Verify getting velocity
-    @assertEqual(lightSpeed, this % p_CE % getVelocity())
+    ! Verify getting speed
+    @assertEqual(lightSpeed, this % p_CE % getSpeed())
 
   end subroutine testMiscAccess
 

--- a/ParticleObjects/particle_class.f90
+++ b/ParticleObjects/particle_class.f90
@@ -136,7 +136,7 @@ module particle_class
     procedure, non_overridable :: getType
 
     ! Enquiry about physical state
-    procedure :: getVelocity
+    procedure :: getSpeed
 
     ! Operations on coordinates
     procedure :: moveGlobal
@@ -427,38 +427,38 @@ contains
   end function getType
 
   !!
-  !! Return the particle velocity in [cm/s]
+  !! Return the particle speed in [cm/s]
   !! neutronMass: [MeV]
   !! lightSpeed:  [cm/s]
   !!
   !! NOTE:
-  !!   The velocities are computed from non-relativistic formula for massive particles.
+  !!   The speeds are computed from non-relativistic formula for massive particles.
   !!   A small error might appear in MeV range (e.g. for fusion applications)
   !!
   !! Args:
   !!   None
   !!
   !! Result:
-  !!   Particle velocity
+  !!   Particle speed
   !!
   !! Errors:
   !!   fatalError if the particle type is neither P_NEUTRON nor P_PHOTON
   !!   fatalError if the particle is MG
   !!
-  function getVelocity(self) result(velocity)
+  function getSpeed(self) result(speed)
     class(particle), intent(in) :: self
-    real(defReal)               :: velocity
-    character(100), parameter   :: Here = 'getVelocity (particle_class.f90)'
+    real(defReal)               :: speed
+    character(100), parameter   :: Here = 'getSpeed (particle_class.f90)'
 
     ! Verify the particle is not MG
-    if (self % isMG) call fatalError(Here, 'Velocity cannot be calculated for MG particle')
+    if (self % isMG) call fatalError(Here, 'Speed cannot be calculated for MG particle')
 
     ! Calculates the velocity for the relevant particle [cm/s]
     if (self % type == P_NEUTRON) then
-      velocity = sqrt(TWO * self % E / neutronMass) * lightSpeed
+      speed = sqrt(TWO * self % E / neutronMass) * lightSpeed
 
     elseif (self % type == P_PHOTON) then
-      velocity = lightSpeed
+      speed = lightSpeed
 
     else
       call fatalError(Here, 'Particle type requested is neither neutron (1) nor photon (2). It is: ' &
@@ -466,7 +466,7 @@ contains
 
     end if
 
-  end function getVelocity
+  end function getSpeed
 
 !!<><><><><><><>><><><><><><><><><><><>><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 !! Particle operations on coordinates procedures

--- a/Tallies/TallyResponses/densityResponse_class.f90
+++ b/Tallies/TallyResponses/densityResponse_class.f90
@@ -15,10 +15,10 @@ module densityResponse_class
   !!
   !! tallyResponse to score particle density contribution
   !!
-  !! Returns the inverse of the particle velocity in [cm/s]
+  !! Returns the inverse of the particle speed in [cm/s]
   !!
   !! NOTE:
-  !!  The velocities are computed from non-relativistic formula for massive particles.
+  !!  The speeds are computed from non-relativistic formula for massive particles.
   !!  The small error might appear in MeV range (e.g. for fusion applications)
   !!
   !! Interface:
@@ -49,7 +49,7 @@ contains
   end subroutine init
 
   !!
-  !! Returns the inverse of the particle velocity (response to score particle density)
+  !! Returns the inverse of the particle speed (response to score particle density)
   !!
   !! See tallyResponse_inter for details
   !!
@@ -59,8 +59,8 @@ contains
     class(nuclearDatabase), intent(inout) :: xsData
     real(defReal)                         :: val
 
-    ! Gets the particle velocity from the particle
-    val = ONE / p % getVelocity()
+    ! Gets the particle speed from the particle
+    val = ONE / p % getSpeed()
 
   end function get
 


### PR DESCRIPTION
A small change. I have changed the slightly misleadingly named 'getVelocity' function in the particle to 'getSpeed'. This is because it is the scalar value we are returning, not the vector. I changed this in the particle, in the test, and in the density response. Hopefully I have included all relevant comments too.