### PR TITLE
Added cells supporting unions

### DIFF
--- a/DataStructures/dictionary_class.f90
+++ b/DataStructures/dictionary_class.f90
@@ -7,11 +7,11 @@ module dictionary_class
   implicit none
   private
   ! Implementation of the dictionary uses finalisation procedures that are implemented into gfortran
-  ! version 4.9 and higher. There is a bug in gfortran untill version 7.0 which causes false warning
+  ! version 4.9 and higher. There is a bug in gfortran until version 7.0 which causes false warning
   ! from -Wsurprising to appear with final procedure. This warning mey be suppressed with
   ! -Wno-surprising flag.
   !
-  ! Becouse of the finalisation local dictionary defined inside procedure will be properly
+  ! Because of the finalisation, any local dictionary defined inside a procedure will be properly
   ! deallocated. Thus:
   !
   !   subroutine memLeak(dictIn)
@@ -26,13 +26,13 @@ module dictionary_class
   ! Maximum size of keyword is equal to nameLen
   !
   ! For now the dictionary is limited to following enteries:
-  ! ->   scalar defReal                                       - real(defReal)      :: a
-  ! ->   1D array of defReal                                  - real(defReal)      :: a(:)
-  ! ->   scalar shortInt                                      - integer(shortInt)  :: i
-  ! ->   1D array of shortInt                                 - integer(shortInt)  :: i(:)
-  ! ->   scalar character of length "charLen" defined below   - character(charLen) :: c
-  ! ->   array of charcters of length "charLen" defined below - character(charLen) :: c(:)
-  ! ->   another dictionary                                   - type(dictionary)   :: dict
+  ! ->   scalar defReal                                        - real(defReal)      :: a
+  ! ->   1D array of defReal                                   - real(defReal)      :: a(:)
+  ! ->   scalar shortInt                                       - integer(shortInt)  :: i
+  ! ->   1D array of shortInt                                  - integer(shortInt)  :: i(:)
+  ! ->   scalar character of length "charLen" defined below    - character(charLen) :: c
+  ! ->   array of characters of length "charLen" defined below - character(charLen) :: c(:)
+  ! ->   another dictionary                                    - type(dictionary)   :: dict
   !
   ! To add additional structure <type> to store it is necessary to :
   ! 0) Define new type parameter for <type> type
@@ -66,7 +66,7 @@ module dictionary_class
   !      or if <type> is too short to fit trimmed content under keyword
   !
   !
-  ! When retreaving real or real Array it is possible to provide keyword associated with an integer
+  ! When retrieving real or real Array it is possible to provide keyword associated with an integer
   ! For following dictionary dict:
   ! integerKey 3;
   ! realKey    3.1;
@@ -86,8 +86,8 @@ module dictionary_class
   integer(shortInt),parameter        :: defStride = 20
 
   !!
-  !! Type to store a single entery in a dictionary
-  !! Uses a single allocatable variable for diffrent type of contant
+  !! Type to store a single entry in a dictionary
+  !! Uses a single allocatable variable for different type of contant
   !!
   type,public :: dictContent
     ! Allocatable space for all content types
@@ -98,8 +98,8 @@ module dictionary_class
     character(charLen)                          :: char0_alloc
     character(charLen),dimension(:),allocatable :: char1_alloc
     ! *** Note that dictionary is defined as pointer not allocatable
-    ! *** This is becouse gfortran < 7.0 does not supports circular derived types with
-    ! *** allocatable keyword. This line may change in a future
+    ! *** This is because gfortran < 7.0 does not supports circular derived types with
+    ! *** allocatable keyword. This line may change in the future
     type(dictionary), pointer                  :: dict0_alloc => null()
 
     ! dictContent type ID
@@ -228,7 +228,7 @@ contains
 
     end if
 
-    ! Check whether keywods contains characters
+    ! Check whether keyword contains characters
     if (adjustl(keyword) == adjustl('')) then
       call fatalError(Here,"Keyword contains only blanks : '' ")
     end if
@@ -307,8 +307,7 @@ contains
     allocate(self % keywords(maxSize))
     allocate(self % entries(maxSize))
 
-
-    ! Keywords can (perhaps?) allocate with some garbage inside. Make shure all enteries are blank.
+    ! Keywords can (perhaps?) allocate with some garbage inside. Make sure all entries are blank.
     self % keywords = ''
 
     if (present(stride)) self % stride = stride
@@ -330,11 +329,11 @@ contains
     entAllocated  = allocated(self % entries)
 
     if(keysAllocated .neqv. entAllocated) then
-      call fatalError(Here,'Immposible state. Keywors or entries is allocated without the other')
+      call fatalError(Here,'Impossible state. Keywords or entries are allocated without the other')
 
     elseif (keysAllocated .and. entAllocated) then
 
-      ! Expression below could extend only to self % dictLen but lets make double shure we
+      ! Expression below could extend only to self % dictLen but lets make double sure we
       ! kill all data. There is no need to optimise this and it is more robust this way.
       do i=1,self % maxSize
         call self % entries(i) % kill()
@@ -461,7 +460,7 @@ contains
         value = real(self % entries(idx) % int0_alloc, defReal)
 
       case default
-        call fatalError(Here,'Entery under keyword ' // keyword // ' is not a real or int')
+        call fatalError(Here,'Entry under keyword ' // keyword // ' is not a real or int')
 
     end select
 
@@ -469,7 +468,7 @@ contains
 
   !!
   !! Loads a real rank 1 from dictionary into provided variable
-  !! If keyword is associated with an integer it converts it to real
+  !! If keyword is associated with an integer it converts it to real.
   !! Variable needs to be allocatable. It will be deallocated before assignment
   !!
   subroutine getRealArray_alloc_new(self,value,keyword)
@@ -491,23 +490,23 @@ contains
         value = real(self % entries(idx) % int1_alloc, defReal)
 
       case default
-        call fatalError(Here,'Entery under keyword ' // keyword // ' is not a real array or int array')
+        call fatalError(Here,'Entry under keyword ' // keyword // ' is not a real array or int array')
 
     end select
 
   end subroutine getRealArray_alloc_new
 
   !!
-  !! Loads a real rank 1 from dictionary into provided variable
-  !! If keyword is associated with an integer it converts it to real
+  !! Loads a real rank 1 from dictionary into provided variable.
+  !! If keyword is associated with an integer it converts it to real.
   !! Variable needs to be pointer. It will be deallocated before assignment
   !!
   subroutine getRealArray_ptr_new(self,value,keyword)
-    class(dictionary), intent(in)                      :: self
-    real(defReal),dimension(:),pointer,intent(inout)   :: value
-    character(*),intent(in)                            :: keyword
-    integer(shortInt)                                  :: idx, N
-    character(100),parameter                           :: Here='getRealArray_ptr (dictionary_class.f90)'
+    class(dictionary), intent(in)                    :: self
+    real(defReal),dimension(:),pointer,intent(inout) :: value
+    character(*),intent(in)                          :: keyword
+    integer(shortInt)                                :: idx, N
+    character(100),parameter                         :: Here='getRealArray_ptr (dictionary_class.f90)'
 
     idx = self % search(keyword, Here, fatal =.true.)
 
@@ -526,14 +525,14 @@ contains
         value = real(self % entries(idx) % int1_alloc, defReal)
 
       case default
-        call fatalError(Here,'Entery under keyword ' // keyword // ' is not a real array or int array')
+        call fatalError(Here,'Entry under keyword ' // keyword // ' is not a real array or int array')
 
     end select
 
   end subroutine getRealArray_ptr_new
 
   !!
-  !! Loads a integer rank 0 from a dictionary
+  !! Loads an integer rank 0 from a dictionary.
   !! If keyword is associated with real integer (i.e. 1.0) it returns an error
   !!
   subroutine getInt_new(self,value,keyword)
@@ -550,15 +549,15 @@ contains
         value = self % entries(idx) % int0_alloc
 
       case default
-        call fatalError(Here,'Entery under keyword ' // keyword // ' is not an integer')
+        call fatalError(Here,'Entry under keyword ' // keyword // ' is not an integer')
 
     end select
 
   end subroutine getInt_new
 
   !!
-  !! Loads a integer rank 1 from a dictionary
-  !! If keyword is associated with real integer (i.e. 1.0) it returns an error
+  !! Loads an integer rank 1 from a dictionary.
+  !! If keyword is associated with real integer (i.e. 1.0) it returns an error.
   !! Variable needs to be allocatable. It will be deallocated before assignment
   !!
   subroutine getIntArray_alloc_new(self,value,keyword)
@@ -577,7 +576,7 @@ contains
         value = self % entries(idx) % int1_alloc
 
       case default
-        call fatalError(Here,'Entery under keyword ' // keyword // ' is not integer array')
+        call fatalError(Here,'Entry under keyword ' // keyword // ' is not integer array')
 
     end select
 
@@ -585,15 +584,15 @@ contains
 
 
   !!
-  !! Loads a integer rank 1 from a dictionary
-  !! If keyword is associated with real integer (i.e. 1.0) it returns an error
+  !! Loads an integer rank 1 from a dictionary.
+  !! If keyword is associated with real integer (i.e. 1.0) it returns an error.
   !! Variable needs to be pointer. It will be deallocated before assignment
   !!
   subroutine getIntArray_ptr_new(self,value,keyword)
-    class(dictionary), intent(in)                            :: self
-    integer(shortInt),dimension(:),pointer,intent(inout)     :: value
-    character(*),intent(in)                                  :: keyword
-    integer(shortInt)                                        :: idx,N
+    class(dictionary), intent(in)                        :: self
+    integer(shortInt),dimension(:),pointer,intent(inout) :: value
+    character(*),intent(in)                              :: keyword
+    integer(shortInt)                                    :: idx,N
     character(100),parameter                   :: Here='getIntArray_ptr (dictionary_class.f90)'
 
     idx = self % search(keyword, Here, fatal =.true.)
@@ -607,7 +606,7 @@ contains
         value = self % entries(idx) % int1_alloc
 
       case default
-        call fatalError(Here,'Entery under keyword ' // keyword // ' is not integer array')
+        call fatalError(Here,'Entry under keyword ' // keyword // ' is not integer array')
 
     end select
 
@@ -635,21 +634,21 @@ contains
         value = self % entries(idx) % char0_alloc
 
       case default
-        call fatalError(Here,'Entery under keyword ' // keyword // ' is not a character')
+        call fatalError(Here,'Entry under keyword ' // keyword // ' is not a character')
 
     end select
 
   end subroutine getChar_new
 
   !!
-  !! Reads a character rank 1 from a dictionary
+  !! Reads a character rank 1 from a dictionary.
   !! Variable needs to be allocatable. It will be deallocated before assignment
   !!
   subroutine getCharArray_alloc_new(self,value,keyword)
-    class(dictionary), intent(in)                             :: self
-    character(*),dimension(:),allocatable,intent(inout)       :: value
-    character(*),intent(in)                                   :: keyword
-    integer(shortInt)                                         :: idx
+    class(dictionary), intent(in)                       :: self
+    character(*),dimension(:),allocatable,intent(inout) :: value
+    character(*),intent(in)                             :: keyword
+    integer(shortInt)                                   :: idx
     character(100),parameter                    :: Here='getCharArray_alloc (dictionary_class.f90)'
 
     idx = self % search(keyword, Here, fatal =.true.)
@@ -661,28 +660,28 @@ contains
         ! Check if the content character fits into value. Any is required becouse len_trim returns
         ! an array
         if( any(len(value) < len_trim(self % entries(idx) % char1_alloc))) then
-          call fatalError(Here,'value character is to short to store content. Increase its length')
+          call fatalError(Here,'value character is too short to store content. Increase its length')
         end if
 
         value = self % entries(idx) % char1_alloc
 
       case default
-        call fatalError(Here,'Entery under keyword ' // keyword // ' is not a character array')
+        call fatalError(Here,'Entry under keyword ' // keyword // ' is not a character array')
 
     end select
 
   end subroutine getCharArray_alloc_new
 
   !!
-  !! Reads a character rank 1 from a dictionary
+  !! Reads a character rank 1 from a dictionary.
   !! Variable needs to be pointer. It will be deallocated before assignment
   !!
   subroutine getCharArray_ptr_new(self,value,keyword)
-    class(dictionary), intent(in)                             :: self
-    character(*),dimension(:),pointer,intent(inout)           :: value
-    character(*),intent(in)                                   :: keyword
-    integer(shortInt)                                         :: idx
-    character(100),parameter                       :: Here='getCharArray_ptr (dictionary_class.f90)'
+    class(dictionary), intent(in)                   :: self
+    character(*),dimension(:),pointer,intent(inout) :: value
+    character(*),intent(in)                         :: keyword
+    integer(shortInt)                               :: idx
+    character(100),parameter                        :: Here='getCharArray_ptr (dictionary_class.f90)'
 
     idx = self % search(keyword, Here, fatal =.true.)
 
@@ -701,7 +700,7 @@ contains
         value = self % entries(idx) % char1_alloc
 
       case default
-        call fatalError(Here,'Entery under keyword ' // keyword // ' is not a character array')
+        call fatalError(Here,'Entry under keyword ' // keyword // ' is not a character array')
 
     end select
 
@@ -724,7 +723,7 @@ contains
         value = self % entries(idx) % dict0_alloc
 
       case default
-        call fatalError(Here,'Entery under keyword ' // keyword // ' is not a dictionary')
+        call fatalError(Here,'Entry under keyword ' // keyword // ' is not a dictionary')
 
     end select
 
@@ -816,8 +815,8 @@ contains
   end subroutine getOrDefault_real
 
   !!
-  !! Loads a real rank 1 from dictionary into provided variable
-  !! If keyword is associated with an integer it converts it to real
+  !! Loads a real rank 1 from dictionary into provided variable.
+  !! If keyword is associated with an integer it converts it to real.
   !! Variable needs to be allocatable. It will be deallocated before assignment
   !!
   !! For further details refer to doc of getOrDefault_real
@@ -842,8 +841,8 @@ contains
   end subroutine getOrDefault_realArray_alloc
 
   !!
-  !! Loads a real rank 1 from dictionary into provided variable
-  !! If keyword is associated with an integer it converts it to real
+  !! Loads a real rank 1 from dictionary into provided variable.
+  !! If keyword is associated with an integer it converts it to real.
   !! Variable needs to be pointer. It will be deallocated before assignment
   !!
   !! For further details refer to doc of getOrDefault_real
@@ -871,7 +870,7 @@ contains
   end subroutine getOrDefault_realArray_ptr
 
   !!
-  !! Loads a integer rank 0 from a dictionary
+  !! Loads a integer rank 0 from a dictionary.
   !! If keyword is associated with real integer (i.e. 1.0) it returns an error
   !!
   !! For further details refer to doc of getOrDefault_real
@@ -894,8 +893,8 @@ contains
   end subroutine getOrDefault_int
 
   !!
-  !! Loads a integer rank 1 from a dictionary
-  !! If keyword is associated with real integer (i.e. 1.0) it returns an error
+  !! Loads a integer rank 1 from a dictionary.
+  !! If keyword is associated with real integer (i.e. 1.0) it returns an error.
   !! Variable needs to be allocatable. It will be deallocated before assignment
   !!
   !! For further details refer to doc of getOrDefault_real
@@ -921,8 +920,8 @@ contains
 
 
   !!
-  !! Loads a integer rank 1 from a dictionary
-  !! If keyword is associated with real integer (i.e. 1.0) it returns an error
+  !! Loads a integer rank 1 from a dictionary.
+  !! If keyword is associated with real integer (i.e. 1.0) it returns an error.
   !! Variable needs to be pointer. It will be deallocated before assignment
   !!
   !! For further details refer to doc of getOrDefault_real
@@ -972,7 +971,7 @@ contains
   end subroutine getOrDefault_char
 
   !!
-  !! Reads a character rank 1 from a dictionary
+  !! Reads a character rank 1 from a dictionary.
   !! Variable needs to be allocatable. It will be deallocated before assignment
   !!
   !! For further details refer to doc of getOrDefault_real
@@ -1000,7 +999,7 @@ contains
   end subroutine getOrDefault_charArray_alloc
 
   !!
-  !! Reads a character rank 1 from a dictionary
+  !! Reads a character rank 1 from a dictionary.
   !! Variable needs to be pointer. It will be deallocated before assignment
   !!
   !! For further details refer to doc of getOrDefault_real
@@ -1049,11 +1048,11 @@ contains
   !! Returns an array of all keywords
   !!
   !! Arg:
-  !!   keysArr -> allocatable array of nameLen long characters to store keys
+  !!   keysArr -> allocatable array of nameLen long characters to store keys.
   !!              Will be reallocated if it was allocated
   !!   type    -> optional character to specify type of keys to be returned
   !!
-  !! Avalible types {'all','real','realArray','int','intArray','char','charArray','dict'}
+  !! Available types {'all','real','realArray','int','intArray','char','charArray','dict'}
   !! Case sensitive! TODO: make case insensitive
   !!
   !! Errors:
@@ -1076,7 +1075,7 @@ contains
     mask = .true.
 
     if(present(type)) then
-      ! Create approperiate mask. I'm sorry it is so dirty - MAK
+      ! Create appropriate mask. I'm sorry it is so dirty - MAK
       select case(trim(type))
         case('all')
           ! Do nothing
@@ -1099,7 +1098,7 @@ contains
       end select
     end if
 
-    ! Return approperiate keys
+    ! Return appropriate keys
     keysArr = pack(self % keywords(1:L), mask)
 
   end subroutine keys
@@ -1255,12 +1254,12 @@ contains
   end subroutine store_dict
 
   !!
-  !! Function to search for the bin associated with a keyword
-  !! Throws more redable error messages for failed searches
+  !! Function to search for the bin associated with a keyword.
+  !! Throws more readable error messages for failed searches
   !!
   !! Args:
   !!   keyword -> character with keyword to be found
-  !!   where -> character string with location of faliure for clearer Error masseges
+  !!   where -> character string with location of faliure for clearer Error messages
   !!   fatal -> logical to control error behaviour. Optional with default = .true.
   !!
   !! Returns:
@@ -1308,10 +1307,9 @@ contains
     ! Copy dictContent type
     LHS % type = RHS % type
 
-    ! Copy individual enteries
+    ! Copy individual entries
     LHS % int0_alloc = RHS % int0_alloc
     if (allocated( RHS % int1_alloc)) LHS % int1_alloc = RHS % int1_alloc
-
 
     LHS % real0_alloc = RHS % real0_alloc
     if (allocated( RHS % real1_alloc)) LHS % real1_alloc = RHS % real1_alloc

--- a/DataStructures/dynArray_class.f90
+++ b/DataStructures/dynArray_class.f90
@@ -83,7 +83,7 @@ contains
   end subroutine add_array_shortInt
 
   !!
-  !! Make shure that array will have memory to fit (newSize) of entries
+  !! Make sure that array will have memory to fit (newSize) of entries
   !! NOTE: does nothing if newSize <= current memory size
   !!
   pure subroutine resize_shortInt(self, newSize)
@@ -166,13 +166,13 @@ contains
   end function expose_shortInt
 
   !!
-  !! Return the entire dynamic array as a static array
+  !! Return a value from the array at a given index
   !!
   function get_shortInt(self, idx) result(res)
     class(dynIntArray), intent(in)              :: self
     integer(shortInt), intent(in)               :: idx
     integer(shortInt)                           :: res
-    character(100), parameter :: Here = 'expose_shortInt (dynArray_Class.f90)'
+    character(100), parameter :: Here = 'get_shortInt (dynArray_Class.f90)'
 
     if (allocated(self % array)) then
       res = self % array(idx)
@@ -219,7 +219,7 @@ contains
     character(100),parameter :: Here = 'pop_shortInt (dynArray_class.f90)'
 
     if(self % isEmpty()) then
-      call fatalError(Here,'Poping from empty array')
+      call fatalError(Here,'Popping from empty array')
     end if
 
     res = self % array(self % mySize)

--- a/Geometry/Cells/CMakeLists.txt
+++ b/Geometry/Cells/CMakeLists.txt
@@ -2,8 +2,10 @@ add_sources( ./cell_inter.f90
              ./cellFactory_func.f90
              ./cellShelf_class.f90
              ./simpleCell_class.f90
+             ./unionCell_class.f90
            )
 
 add_unit_tests( ./Tests/simpleCell_test.f90
-                ./Tests/cellShelf_test.f90
+	        ./Tests/unionCell_test.f90
+		./Tests/cellShelf_test.f90
               )

--- a/Geometry/Cells/Tests/unionCell_test.f90
+++ b/Geometry/Cells/Tests/unionCell_test.f90
@@ -1,0 +1,166 @@
+module unionCell_test
+
+  use numPrecision
+  use dictionary_class,   only : dictionary
+  use dictParser_func,    only : charToDict
+  use surfaceShelf_class, only : surfaceShelf
+  use unionCell_class,    only : unionCell
+  use funit
+
+  implicit none
+
+  ! Parameters
+  character(*), parameter :: SURF_DEF = "&
+  & surf1 { id 13; type sphere; origin (0.0 0.0 0.0); radius 5.0;} &
+  & surf2 { id 15; type box; origin (0.0 0.0 0.0); halfwidth ( 4.6 4.6 4.6);} &
+  & surf3 { id 4;  type xTruncCylinder; origin (0 0 0); halfwidth 5.1; radius 1.0;} &
+  & surf4 { id 5;  type yTruncCylinder; origin (0 0 0); halfwidth 5.1; radius 1.0;} &
+  & surf5 { id 6;  type zTruncCylinder; origin (0 0 0); halfwidth 5.1; radius 1.0;} "
+
+  ! Note that fill is not really needed to build a cell. It is used by cellShelf only
+  character(*), parameter :: EASYCELL_DEF = "&
+  & id 2; type unionCell; surfaces [-13 -15 ]; filltype outside; "
+  character(*), parameter :: COMPLEXCELL_DEF = "&
+  & id 3; type simpleCell; surfaces [< -13 -15 > # < -4 : -5 : -6 > ]; filltype outside; "
+
+
+  ! Variables
+  type(surfaceShelf) :: surfs
+  type(unionCell)    :: easyCell, complexCell
+
+contains
+
+  !!
+  !! Build the cell
+  !!
+@Before
+  subroutine setUp()
+    type(dictionary) :: dict
+
+    call charToDict(dict, SURF_DEF)
+    call surfs % init(dict)
+    call dict % kill()
+    call charToDict(dict, EASYCELL_DEF)
+    call easyCell % init(dict, surfs)
+    call dict % kill()
+    call charToDict(dict, COMPLEXCELL_DEF)
+    call complexCell % init(dict, surfs)
+
+  end subroutine setUp
+
+  !!
+  !! Clean after tests
+  !!
+@After
+  subroutine cleanUp()
+
+    call surfs % kill()
+    call easyCell % kill()
+    call complexCell % kill()
+
+  end subroutine cleanUp
+
+  !!
+  !! Test Miscellaneous functionality
+  !!
+@Test
+  subroutine test_misc()
+
+    ! Test Id
+    @assertEqual(3, complexCell % id())
+
+    call complexCell % setID(7)
+    @assertEqual(7, complexCell % id())
+
+  end subroutine test_misc
+
+
+  !!
+  !! Test inside/outside determination
+  !!
+@Test
+  subroutine test_inside()
+    real(defReal), dimension(3) :: r, u
+
+    u = [ONE, ZERO, ZERO]
+    
+    ! Few points inside
+    r = [-4.59_defReal, 0.0_defReal, 0.0_defReal]
+    @assertTrue( easyCell % inside(r, u))
+
+    r = [0.3_defReal, 1.3_defReal, 0.4_defReal]
+    @assertTrue( easyCell % inside(r, u))
+
+    r = [3.0_defReal, 2.3_defReal, 0.4_defReal]
+    @assertTrue( complexCell % inside(r, u))
+
+    r = [-1.1_defReal, 1.05_defReal, 0.0_defReal]
+    @assertTrue( complexCell % inside(r, u))
+
+    ! Few points outside
+    r = [0.0_defReal, 4.9_defReal, 0.0_defReal]
+    @assertFalse( easyCell % inside(r, u))
+
+    r = [4.58_defReal, 4.58_defReal, -4.58_defReal]
+    @assertFalse( easyCell % inside(r, u))
+    
+    r = [0.1_defReal, 0.3_defReal, -0.2_defReal]
+    @assertFalse( complexCell % inside(r, u))
+    
+    r = [-4.59_defReal, 0.0_defReal, 0.25_defReal]
+    @assertFalse( complexCell % inside(r, u))
+    
+    r = [4.58_defReal, 4.58_defReal, -4.58_defReal]
+    @assertFalse( complexCell % inside(r, u))
+
+  end subroutine test_inside
+
+  !!
+  !! Test distance calculations
+  !!
+@Test
+  subroutine test_distance()
+    real(defReal), dimension(3) :: r, u
+    real(defReal)               :: ref, d
+    integer(shortInt)           :: idx, idx_ref
+    real(defReal), parameter :: TOL = 1.0E-6
+
+    ! Points inside
+    r = [0.2_defReal, -0.1_defReal, 0.0_defReal]
+    u = [-0.980580676_defReal, ZERO, 0.196116135_defReal]
+    ref = 4.895058733_defReal
+    idx_ref = surfs % getIdx(15)
+    call easyCell % distance(d, idx, r, u)
+    @assertEqual(ref, d, TOL * ref)
+    @assertEqual(idx_ref, idx)
+
+    ! Point outside - should hit an imaginary sphere surface
+    r = [6.0_defReal, 0.0_defReal, 0.0_defReal]
+    u = [-ONE, ZERO, ZERO]
+    ref = ONE
+    idx_ref = surfs % getIdx(13)
+    call easyCell % distance(d, idx, r, u)
+    @assertEqual(ref, d, TOL * ref)
+    @assertEqual(idx_ref, idx)
+    
+    ! Point outside - should hit a real sphere surface
+    r = [4.5_defReal, 4.5_defReal, 4.5_defReal]
+    u = -0.577350269_defReal
+    ref = 2.794228634_defReal
+    idx_ref = surfs % getIdx(13)
+    call easyCell % distance(d, idx, r, u)
+    @assertEqual(ref, d, TOL * ref)
+    @assertEqual(idx_ref, idx)
+
+    ! Cylinder hit
+    r = [1.2_defReal, 0.0_defReal, 0.0_defReal]
+    u = [ZERO, -ONE, ZERO]
+    ref = ONE
+    idx_ref = surfs % getIdx(4)
+    call complexCell % distance(d, idx, r, u)
+    @assertEqual(ref, d, TOL * ref)
+    @assertEqual(idx_ref, idx)
+
+  end subroutine test_distance
+
+end module unionCell_test

--- a/Geometry/Cells/cellFactory_func.f90
+++ b/Geometry/Cells/cellFactory_func.f90
@@ -10,13 +10,15 @@ module cellFactory_func
 
   ! Cells
   use simpleCell_class,   only : simpleCell
+  use unionCell_class,    only : unionCell
 
   implicit none
   private
 
   ! List that contains acceptable types of cells
   ! NOTE: It is necessary to adjust trailing blanks so all entries have the same length
-  character(nameLen), dimension(*), parameter :: AVAILABLE_CELL = ['simpleCell']
+  character(nameLen), dimension(*), parameter :: AVAILABLE_CELL = ['simpleCell', &
+                                                                   'unionCell ']
 
   ! Public Interface
   public :: new_cell_ptr
@@ -51,6 +53,9 @@ contains
     select case (type)
       case ('simpleCell')
         allocate(simpleCell :: new)
+      
+      case ('unionCell')
+        allocate(unionCell :: new)
 
       case default
         print '(A)', 'AVAILABLE CELLS: '

--- a/Geometry/Cells/cell_inter.f90
+++ b/Geometry/Cells/cell_inter.f90
@@ -3,6 +3,7 @@ module cell_inter
   use numPrecision
   use genericProcedures,  only : fatalError, numToChar
   use dictionary_class,   only : dictionary
+  use surface_inter,      only : surface
   use surfaceShelf_class, only : surfaceShelf
 
   implicit none
@@ -10,6 +11,20 @@ module cell_inter
 
   ! Extendable procedures
   public :: kill
+  
+
+  !!
+  !! Type to hold pointer to a surface together with a halfspace information
+  !!
+  !! Public Members:
+  !!   surfIdx -> Index of the surface (+ve if +ve halspace is used to define the
+  !!     cell, -ve otherwise)
+  !!   ptr -> Pointer to a surface
+  !!
+  type, public :: surfInfo
+    integer(shortInt)       :: surfIdx = 0
+    class(surface), pointer :: ptr => null()
+  end type surfInfo
 
   !!
   !! Abstract interface for all cells

--- a/Geometry/Cells/simpleCell_class.f90
+++ b/Geometry/Cells/simpleCell_class.f90
@@ -6,24 +6,10 @@ module simpleCell_class
   use dictionary_class,   only : dictionary
   use surfaceShelf_class, only : surfaceShelf
   use surface_inter,      only : surface
-  use cell_inter,         only : cell, kill_super => kill
+  use cell_inter,         only : cell, surfInfo, kill_super => kill
 
   implicit none
   private
-
-  !!
-  !! Local type to hold pointer to a surface together with a halfspace information
-  !!
-  !! Public Members:
-  !!   surfIdx -> Index of the surface (+ve if +ve halspace is used to define the
-  !!     cell, -ve otherwise)
-  !!   ptr -> Pointer to a surface
-  !!
-  type :: surfInfo
-    integer(shortInt)       :: surfIdx = 0
-    class(surface), pointer :: ptr => null()
-  end type
-
 
   !!
   !! CSG cell defined by intersection of halfspaces
@@ -108,7 +94,7 @@ contains
     integer(shortInt)                       :: i
     logical(defBool)                        :: halfspace, sense
 
-    ! Keep compiler happy (in immpossible case of cell with no surfaces)
+    ! Keep compiler happy (in impossible case of cell with no surfaces)
     isIt = .false.
 
     do i= 1, size(self % surfaces)

--- a/Geometry/Cells/unionCell_class.f90
+++ b/Geometry/Cells/unionCell_class.f90
@@ -1,0 +1,477 @@
+module unionCell_class
+
+  use numPrecision
+  use universalVariables, only : INF
+  use genericProcedures,  only : fatalError, hasDuplicates, numToChar, charToInt
+  use dictionary_class,   only : dictionary
+  use surfaceShelf_class, only : surfaceShelf
+  use surface_inter,      only : surface
+  use cell_inter,         only : cell, surfInfo, kill_super => kill
+
+  implicit none
+  private
+
+  ! Define CSG operators
+  integer(shortInt), parameter :: union     = huge(shortInt) - 1, &
+                                  intersect = union - 1, &
+                                  openBra   = union - 2, &
+                                  closeBra  = union - 3, &
+                                  complem   = union - 4
+
+
+  !!
+  !! CSG cell defined by intersections and unions of halfspaces
+  !!
+  !! This cell is a generalisation of the simpleCell.
+  !! It allows intersections, unions, and complements.
+  !!
+  !! It is equipped with its own syntax to perform parentheses and to
+  !! denote a union.
+  !! These are:
+  !!   union = :
+  !!   open parenthesis = <
+  !!   close parenthesis = >
+  !!   complement = #
+  !! These are used as entries in the surface list
+  !! As with the simple cell, intersections are implicit.
+  !!
+  !! Sample input dictionary:
+  !!   cell {
+  !!     type unionCell;
+  !!     id 17;
+  !!     surfaces [ 3 ~ < -1 + 2 > ];
+  !!     <content info as defined in cellShelf_class >
+  !!   }
+  !! NOTE: surfaces is not a list but a tokenArray, using [ ], not ( )
+  !!
+  !! Private Members:
+  !!   surfaces  -> Array that contains, halfspace info, surfIdx and a pointer to the surface.
+  !!     Negative halfspace is indicated by surfIdx < 0. Positive by surfIdx > 0
+  !!   evalArray -> Array containing surfaces and operations necessary to evaluate whether
+  !!                a point lies inside the cell
+  !!   isSimple  -> Logical identifying whether the cell is only composed of intersections.
+  !!                If so, simplifies evaluation logic.
+  !!
+  !! Interface:
+  !!   cell interface
+  !!
+  type, public, extends(cell) :: unionCell
+    private
+    type(surfInfo), dimension(:), allocatable    :: surfaces
+    integer(shortInt), dimension(:), allocatable :: evalArray
+    logical(defBool)                             :: isSimple = .false.
+  contains
+    procedure :: init
+    procedure :: deMorgan
+    procedure :: checkPrecedence
+    procedure :: inside
+    procedure :: insideComplex
+    procedure :: shortCircuit
+    procedure :: distance
+    procedure :: kill
+  end type unionCell
+
+contains
+
+  !!
+  !! Initialise cell
+  !!
+  !! See cell_inter for details
+  !!
+  subroutine init(self, dict, surfs)
+    class(unionCell), intent(inout)   :: self
+    class(dictionary), intent(in)     :: dict
+    type(surfaceShelf), intent(inout) :: surfs
+    logical(defBool)                  :: notInt, surfacePrev, closePrev, hasUnion
+    integer(shortInt)                 :: surfIdx, id, i, evalSize, num, sCount, depth
+    character(nameLen), dimension(:), allocatable :: definition
+    integer(shortInt), dimension(:), allocatable  :: tempEval
+    type(surfInfo), dimension(:), allocatable     :: tempSurf
+    character(100), parameter :: Here = 'init (unionCell_class.f90)'
+
+    ! Get surfaces and operations from dictionary
+    call dict % get(definition, 'surfaces')
+
+    ! Allocate initial arrays with a worst-case size
+    allocate(tempEval(2*size(definition)))
+    tempEval = 0
+    allocate(tempSurf(size(definition)))
+
+    ! Check to make sure all entries are either a recognised operation
+    ! or a surface ID. 
+    ! Also checks how many elements are required to evaluate the cell.
+    ! Track depth of nesting to ensure consistency in input.
+    surfacePrev = .false.
+    closePrev = .false.
+    evalSize = 0
+    sCount = 0
+    depth = 0
+    do i = 1, size(definition)
+      
+      ! Check if definition can be converted to a number
+      notInt = .false.
+      num = charToInt(definition(i), notInt)
+      
+      ! Check if definition is a recognised symbol
+      if (notInt) then
+
+        evalSize = evalSize + 1
+        
+        select case(definition(i))
+          case('<')
+            depth = depth + 1
+            if (surfacePrev .or. closePrev) then
+              tempEval(evalSize) = intersect
+              evalSize = evalSize + 1
+            end if
+            tempEval(evalSize) = openBra
+            closePrev = .false.
+          case('>')
+            depth = depth - 1
+            tempEval(evalSize) = closeBra
+            closePrev = .true.
+          case(':')
+            tempEval(evalSize) = union
+            closePrev = .false.
+          case('#')
+            if (surfacePrev .or. closePrev) then
+              tempEval(evalSize) = intersect
+              evalSize = evalSize + 1
+            end if
+            tempEval(evalSize) = complem
+            closePrev = .false.
+          case default
+            call fatalError(Here,'Unrecognised entry in surfaces: '//definition(i))
+        end select
+        surfacePrev = .false.
+
+      ! Otherwise, it's a surface
+      else
+
+        ! Insert intersection operation in the tree
+        ! as it is implicit in the input
+        if (surfacePrev .or. closePrev) then
+          evalSize = evalSize + 1
+          tempEval(evalSize) = intersect
+        end if
+        evalSize = evalSize + 1
+        sCount = sCount + 1
+        
+        tempEval(evalSize) = sCount
+        surfIdx = surfs % getIdx(abs(num))
+        tempSurf(sCount) % ptr => surfs % getPtr(surfIdx)
+        tempSurf(sCount) % surfIdx = sign(surfIdx, num)
+
+        surfacePrev = .true.
+        closePrev = .false.
+
+      end if
+
+    end do
+
+    ! Sense checks
+    if (depth /= 0) call fatalError(Here,'Inconsistent use of parentheses in cell definition')
+    if (tempEval(evalSize) == union) call fatalError(Here, 'Cell definition ends with a union')
+    if (tempEval(evalSize) == complem) call fatalError(Here, 'Cell definition ends with a complement')
+
+    allocate(self % surfaces(sCount))
+    self % surfaces = tempSurf(1:sCount)
+    deallocate(tempSurf)
+
+    ! Apply De Morgan's law to replace complements
+    call self % deMorgan(tempEval, evalSize)
+
+    allocate(self % evalArray(evalSize))
+    self % evalArray = tempEval(1:evalSize)
+    deallocate(tempEval)
+    
+    ! Check brackets. These must be used appropriately to enforce precedence between
+    ! different operations. If not, return an error due to ambiguity of operations.
+    call self % checkPrecedence()
+
+    ! Check whether the cell is simple
+    hasUnion = .false.
+    do i = 1, size(self % evalArray)
+      if (self % evalArray(i) == union) hasUnion = .true.
+    end do
+    self % isSimple = .not. hasUnion
+
+    ! Get cell ID
+    call dict % get(id, 'id')
+    call self % setId(id)
+
+    ! Check surfaces for duplicates
+    if (hasDuplicates(abs(self % surfaces % surfIdx))) then
+      call fatalError(Here, 'There are repeated surfaces in definition of cell: '//numToChar(id))
+    end if
+
+  end subroutine init
+
+  !!
+  !! Remove complements, applying DeMorgan's law to invert surface senses
+  !! and replace unions with intersections and vice versa.
+  !! Applies complements to entire parentheses.
+  !!
+  subroutine deMorgan(self, array, sz)
+    class(unionCell), intent(inout)                             :: self
+    integer(shortInt), dimension(:), allocatable, intent(inout) :: array
+    integer(shortInt), intent(inout)                            :: sz
+    integer(shortInt)                                           :: i, j, depth, endPos
+    
+    i = 1
+    do while (i < sz)
+      if (array(i) == complem) then
+        ! Delete the complement
+        array(i:sz-1) = array(i+1:sz)
+        sz = sz - 1
+
+        ! If a parenthesis is opened, complement its contents.
+        ! Otherwise only complement the current position
+        endPos = i
+        if (array(i) == openBra) then
+          depth = 1
+          do j = i + 1, sz
+            if (array(j) == openBra) then
+              depth = depth + 1
+            elseif (array(j) == closeBra) then
+              depth = depth - 1
+            end if
+            if (depth == 0) exit
+          end do
+          endpos = min(j, sz)
+        end if
+
+        ! Proceed until the end of the nesting, applying the complement
+        do j = i, endPos
+          if (array(j) < complem) then
+            self % surfaces(array(j)) % surfIdx = -self % surfaces(array(j)) % surfIdx
+          elseif (array(j) == union) then
+            array(j) = intersect
+          elseif (array(j) == intersect) then
+            array(j) = union
+          end if
+        end do
+
+      end if
+      i = i + 1
+    end do
+    
+  end subroutine deMorgan
+
+  !!
+  !! Check to make sure that brackets are used appropriately to avoid ambiguous operations.
+  !! The use of a union on a surface followed by an intersection is ambiguous as these
+  !! operations do not commute. Rather than assuming a precedence, the code will return
+  !! an error if this is the case. This can be fixed by use of brackets to enforce a
+  !! user-specified order of operations.
+  !!
+  subroutine checkPrecedence(self)
+    class(unionCell), intent(in) :: self
+    integer(shortInt)            :: i, j, el1, el2
+    character(100), parameter    :: Here = 'checkPrecedence (unionCell_class.f90)'
+
+    ! Go through all elements, checking for unions/intersections which
+    ! are not separated by brackets.
+    i = 1
+    outer: do while(i < size(self % evalArray))
+      
+      el1 = self % evalArray(i)
+
+      if ((el1 == union) .or. (el1 == intersect)) then
+
+        j = i + 1
+
+        inner: do while(j <= size(self % evalArray))
+
+          el2 = self % evalArray(j)
+          if ((el2 == intersect) .or. (el2 == union)) then
+
+            if (el2 /= el1) then
+              call fatalError(Here,'The order of operations in a cell is ambiguous')
+            else
+              i = j
+              cycle outer
+            end if
+
+          else if((el2 == openBra) .or. (el2 == closeBra)) then
+            
+            ! A parenthesis is opened or closed, making the operations unambiguous.
+            ! Skip to the next element after the bracket.
+            i = j + 1
+            cycle outer
+
+          end if
+          j = j + 1
+
+        end do inner
+
+      end if
+      i = i + 1
+
+    end do outer
+
+
+  end subroutine checkPrecedence
+
+  !!
+  !! Return .true. if position is inside the cell
+  !!
+  !! Branches depending on whether the cell is simple or complex.
+  !!
+  !! See cell_inter for details
+  !!
+  pure function inside(self, r, u) result(isIt)
+    class(unionCell), intent(in)            :: self
+    real(defReal), dimension(3), intent(in) :: r
+    real(defReal), dimension(3), intent(in) :: u
+    logical(defBool)                        :: isIt
+    integer(shortInt)                       :: i
+    logical(defBool)                        :: halfspace, sense
+
+    if (self % isSimple) then
+    
+      ! Keep compiler happy (in impossible case of cell with no surfaces)
+      isIt = .false.
+
+      do i= 1, size(self % surfaces)
+        sense = self % surfaces(i) % surfIdx > 0
+        halfspace = self % surfaces(i) % ptr % halfspace(r, u)
+
+        isIt = halfspace .eqv. sense
+
+        ! If halfspace is not equivalent to sense it means that point
+        ! is outside the cell.
+        if(.not.isIt) return
+      end do
+    else
+      isIt = self % insideComplex(r,u)
+    end if
+
+  end function inside
+
+  !!
+  !! Return .true. if position is inside the cell
+  !!
+  !! Follows the infix notation algorithm described by Romano et al.
+  !! 'Point containment algorithms for constructive solid geometry with 
+  !! unbounded primitives'
+  !!
+  !! See cell_inter for details
+  !!
+  pure function insideComplex(self, r, u) result(isIt)
+    class(unionCell), intent(in)            :: self
+    real(defReal), dimension(3), intent(in) :: r
+    real(defReal), dimension(3), intent(in) :: u
+    logical(defBool)                        :: isIt
+    integer(shortInt)                       :: i, idx, depth, el
+    logical(defBool)                        :: halfspace, sense
+
+    isIt = .true.
+    depth = 0
+    i = 1
+
+    do while (i <= size(self % evalArray))
+
+      el = self % evalArray(i)
+      
+      ! The element is a surface
+      if (el < complem) then
+        idx = self % evalArray(i)
+        sense = self % surfaces(idx) % surfIdx > 0
+        halfspace = self % surfaces(idx) % ptr % halfspace(r, u)
+        isIt = halfspace .eqv. sense
+
+      elseif (((el == union) .and. isIt) .or. &
+               ((el == intersect) .and. .not. isIt)) then
+
+        if (depth == 0) then 
+          return
+        else
+          depth = depth - 1
+          call self % shortCircuit(i)
+        end if
+
+      elseif (el == openBra) then
+        depth = depth + 1
+
+      elseif (el == closeBra) then
+        depth = depth - 1
+
+      end if
+      i = i + 1
+    end do
+
+  end function insideComplex
+
+  !!
+  !! Subroutine to short circuit inside cell evaluation.
+  !! Skips the array index forward to the end of a parenthesis.
+  !! Also described by Romano et al.
+  !!
+  pure subroutine shortCircuit(self, i)
+    class(unionCell), intent(in)     :: self
+    integer(shortInt), intent(inout) :: i
+    integer(shortInt)                :: d, el
+
+    d = 1
+    ! Searches for end of the parenthesis
+    do while (d > 0)
+      i = i + 1
+      el = self % evalArray(i)
+
+      if (el == openBra) then
+        d = d + 1
+      else if (el == closeBra) then
+        d = d - 1
+      end if
+
+    end do
+
+  end subroutine shortCircuit
+
+  !!
+  !! Return distance to cell boundary
+  !!
+  !! See cell_inter for details
+  !!
+  pure subroutine distance(self, d, surfIdx, r, u)
+    class(unionCell), intent(in)            :: self
+    real(defReal), intent(out)              :: d
+    integer(shortInt), intent(out)          :: surfIdx
+    real(defReal), dimension(3), intent(in) :: r
+    real(defReal), dimension(3), intent(in) :: u
+    integer(shortInt)                       :: i
+    real(defReal)                           :: test_d
+
+    d = INF
+    surfIdx = 0
+
+    do i = 1, size(self % surfaces)
+      test_d = self % surfaces(i) % ptr % distance(r, u)
+
+      ! Select minimum distance
+      if (test_d < d) then
+        d = test_d
+        surfIdx = i
+      end if
+    end do
+
+  end subroutine distance
+
+  !!
+  !! Return to uninitialised state
+  !!
+  elemental subroutine kill(self)
+    class(unionCell), intent(inout) :: self
+
+    ! Call superclass procedure
+    call kill_super(self)
+
+    ! Clean local
+    if(allocated(self % evalArray)) deallocate (self % evalArray)
+    if(allocated(self % surfaces)) deallocate (self % surfaces)
+    self % isSimple = .false.
+
+  end subroutine kill
+
+end module unionCell_class

--- a/docs/Dictionary Input.rst
+++ b/docs/Dictionary Input.rst
@@ -8,12 +8,13 @@ ASCII Dictionary Syntax
 
 SCONE uses a hierarchical input that is composed of nested dictionaries
 that contain some content associated with a keyword unique within the scope
-of a single dictionary. Following content is available:
+of a single dictionarya. The following content is available:
 
 * Word with no spaces or ";" e.g. ThisIsContent
 * Integer number e.g. 1
 * Real number e.g. 2.78
 * List of Words, Integers or Reals
+* `TokenArray`, a possibly mixed list of words and numbers
 * Subdictionary
 
 Hierarchical structure of dictionaries can be loaded from ASCII files and be
@@ -34,6 +35,8 @@ OpenFOAM syntax is supported. An example of the correct input dictionary is::
 
       word Horace;
       words (Non omnis moriar);
+
+      tokens [I can count to 3.1415]; ! Read as an array of characters
 
       ! Subdictionary
       greeks{ poet Homer; politician Pericles; hero Theseus; }
@@ -81,6 +84,7 @@ of SCONE dictionary grammar in BNF notation is::
     <intList>     ::= (" "* <int> " "+)+
     <realList>    ::= (" "* (<int>|<real>)" "+)* (" "* <real>" "+)+ (" "* (<int>|<real>)" "+)*
     <wordList>    ::= (" "* <word> " "+)+
+    <tokenArray>  ::= [" "* <int>|<real>|word> " "+]+
 
 For compactness definitions of ``<int>``, ``<real>`` and ``<word>`` are omitted.
 They have the following meaning::

--- a/docs/User Manual.rst
+++ b/docs/User Manual.rst
@@ -559,10 +559,20 @@ Similarly to the surfaces, the **cells** in the geometry can be defined as: ::
       <nameN> { id <idNumberN>; type <cellType>; surfaces (<surfaces>); filltype <fillType>; *keywords* }
       }
 
-At the moment, in SCONE, the only ``cellType`` available is ``simpleCell``.
-In the surface definition, one should include the indexes of the corresponding
-surfaces with no sign to indicate a positive half-space, or minus sign to indicate
-a negative half-space. The space in between cells corresponds to an intersection.
+SCONE supports two ``cellTypes``: ``simpleCell`` and ``unionCell``.
+These types differ by the form and content of their surfaces.
+For ``simpleCell``, surfaces is a standard list of surfaces.
+This list should  include the indexes of the corresponding surfaces, with no sign 
+to indicate a positive half-space, or minus sign to indicate a negative half-space. 
+The space in between cells corresponds to an intersection.
+For ``unionCell``, surfaces is no longer a list, but a ``tokenArray``, i.e., an array
+delimited by ``[`` and ``]``, with entries separated by whitespace. This is to allow a
+mixture of numbers and symbols. Like ``simpleCell``, ``unionCell`` includes surfaces 
+and signs to indicate their halfspace. However, it is also endowed with additional
+operators to define the cell. As well as an implicit intersection operator, there is
+the union, ``:``, the complement, ``#``, and brackets to enforce an order of operations,
+``<`` and ``>``. This ``cellType`` encompasses ``simpleCell`` and can replace it without
+any problem.
 
 The possible ``fillTypes`` are:
 
@@ -580,7 +590,7 @@ Example: ::
 
 Example: ::
 
-      cellX { id 5; type simpleCell; surfaces (2 -3); filltype uni; universe 6; }
+      cellX { id 5; type unionCell; surfaces [2 : -3 # < 4 5 >]; filltype uni; universe 6; }
 
 * outside: if the cell is outside of the geometry
 


### PR DESCRIPTION
There is a new cell type which supports unions, complements, and parentheses. It uses infix notation, inspired by the results of Paul Romano et al.'s recent paper.

There are several style/code structure questions that should be resolved here. 

First, this cell essentially supercedes the simpleCell. Do we want to get rid of the simpleCell? It might be code duplication otherwise and I can't think of a very good case for keeping it. Maybe we wait a little while until we're comfortable with this one.

Second, for the operators necessary, reading them in alongside the surfaces required a deviation in input parsing/reading. Currently lists do not allow mixed number/character arrays. Hence I created the 'tokenArray' to contain arbitrary white-space separated characters of any format. These are read into a character array - I convert the numbers back to integers inside unionCell. It is denoted by using square brackets. Is this acceptable? Is there a nicer way of doing this? This also requires that surfaces and operators be delimited by spaces - maybe this isn't strictly necessary if I put some more logic inside the unionCell itself, for example. I would especially like to resolve this quickly because it will affect the input format and it would be great to settle that quickly so that we can start using this, e.g., with csg2csg.

I have also written a unit test and changed some comments in other nearby files.