### PR TITLE
Small fixes in cones and trackingHT

### DIFF
--- a/Geometry/Surfaces/QuadSurfaces/cone_class.f90
+++ b/Geometry/Surfaces/QuadSurfaces/cone_class.f90
@@ -145,7 +145,9 @@ contains
     end if
 
     if (hMin >= hMax) call fatalError(Here, 'hMin is greater than or equal to hMax.')
-    if (sign(hMin,hMax) /= hMin) call fatalError(Here, 'hMin and hMax have different signs.')
+    if ((sign(hMin,hMax) /= hMin) .and. hMin /= ZERO .and. hMax /= ZERO) then
+      call fatalError(Here, 'hMin and hMax have different signs.')
+    end if
 
     ! Load properties
     self % vertex = vertex

--- a/TransportOperator/transportOperatorHT_class.f90
+++ b/TransportOperator/transportOperatorHT_class.f90
@@ -57,11 +57,15 @@ contains
     ! Get majornat XS inverse: 1/Sigma_majorant
     majorant_inv = ONE / self % xsData % getTrackingXS(p, p % matIdx(), MAJORANT_XS)
 
-    ! Obtain the local cross-section
-    sigmaT = self % xsData % getTrackMatXS(p, p % matIdx())
+    ! Obtain the local cross-section. Always choose ST in void
+    if (p % matIdx() == VOID_MAT) then
+      sigmaT = ZERO
+    else
+      sigmaT = self % xsData % getTrackMatXS(p, p % matIdx())
+    end if
 
     ! Calculate ratio between local cross-section and majorant
-    ratio = sigmaT*majorant_inv
+    ratio = sigmaT * majorant_inv
 
     ! Cut-off criterion to decide on tracking method
     if (ratio > (ONE - self % cutoff)) then
@@ -104,7 +108,7 @@ contains
       end if
 
       ! Check for void
-      if(p % matIdx() == VOID_MAT) then
+      if (p % matIdx() == VOID_MAT) then
         call tally % reportInColl(p, .true.)
         cycle DTLoop
       end if


### PR DESCRIPTION
Two small fixes:

1. Cones throw a fatal error if the two bases (which define the orientation of the cone) have different signs. This was the case even when one the bases was zero. Now, one of the two is allowed to be zero.
2. HT would throw a fatal error if the tracking method selection happened on a particle in void (because this means a material XS lookup in void was attempted). Now ST is chosen if the particle is in void.