### PR TITLE
Add backtrace to error message for key errors

### DIFF
--- a/DataStructures/Tests/dictionary_test.f90
+++ b/DataStructures/Tests/dictionary_test.f90
@@ -549,4 +549,64 @@ contains
   end subroutine testGetSize
 
 
+@test
+  subroutine testAddressOfNodes(this)
+    class(test_dictionary), intent(inout) :: this
+    type(dictionary)          :: workDict, workDict2
+    type(dictionary), pointer :: dictPtr => null()
+    character(nameLen) :: keyword
+    character(:), allocatable :: tempString
+    integer(shortInt)  :: i
+
+    dictPtr => this % dict % getDictPtr('nestedDict')
+
+    ! ! Verify node address following normal construction
+    @assertEqual("/", this % dict % address)
+    @assertEqual("/nestedDict/", dictPtr % address)
+
+    ! We need to verify a case when we copy dictionary out
+    ! all dictionaries nested deeper must have their address updated correctly
+    ! Add more nesting
+    call workDict % init(1)
+    call workDict % store("anInt", 1)
+
+    call workDict2 % init(1)
+    call workDict2 % store("aReal", 1.0_defReal)
+
+    call workDict % store("subsubsubDict", workDict2)
+
+    call dictPtr % store("subsubDict", workDict)
+    call workDict % kill()
+    call workDict2 % kill()
+
+    ! Verify that after storing address is correct
+
+    ! Nested dictionary
+    dictPtr => this % dict % getDictPtr("nestedDict")
+    dictPtr => dictPtr % getDictPtr("subsubDict")
+    tempString = dictPtr % address
+    @assertEqual("/nestedDict/subsubDict/", tempString)
+
+    ! Double nested dictionary
+    dictPtr => dictPtr % getDictPtr("subsubsubDict")
+    tempString = dictPtr % address
+    @assertEqual("/nestedDict/subsubDict/subsubsubDict/", tempString)
+
+    ! Copy out a dictionary
+    call this % dict % get(workDict, "nestedDict")
+
+    @assertEqual("/", workDict % address)
+
+    ! Nested dictionary
+    dictPtr => workDict % getDictPtr("subsubDict")
+    tempString = dictPtr % address
+    @assertEqual("/subsubDict/", tempString)
+
+    ! Double nested dictionary
+    dictPtr => dictPtr % getDictPtr("subsubsubDict")
+    tempString = dictPtr % address
+    @assertEqual("/subsubDict/subsubsubDict/", tempString)
+
+  end subroutine testAddressOfNodes
+
 end module dictionary_test


### PR DESCRIPTION
Fixes part of the usual user experience when working with the dictionary input. 
Now the dictionaries keep track of their address (path?) in the nested dictionary structure and on the key error when requesting the elements of dictionary the location is included in the error message. e.g.:
```
 <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 Fatal has occurred in:
 getInt (dictionary_class.f90)                                                                       

 Because:
 In dictionary [/activeTally/flux/map] Entry under keyword N is not an 
 integer
 <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
```

The things to pay attention in the review are: 
- Some error messages that were missed and not updated 
- Potentially some use sequence of adding/removing/moving dictionaries that is not covered in the test. I fear I might have missed something and would appreciate 2nd pair of eyes 
- We may use this opportunity to reword/cleanup dictionary error messages  