### PR TITLE
Fix bug in building thermalScatterElastic_class.f90

### DIFF
--- a/NuclearData/Reactions/thermalScattReactionCE/thermalScatterElastic_class.f90
+++ b/NuclearData/Reactions/thermalScattReactionCE/thermalScatterElastic_class.f90
@@ -311,7 +311,7 @@ contains
 
       call ACE % setToElasticOut()
       do i = 1, Nin
-        self % muMatrix(i,:) = ACE % readIntArray(Nin)
+        self % muMatrix(i,:) = ACE % readRealArray(self % N_muOut)
       end do
 
     end if


### PR DESCRIPTION
Two errors in one line! That was on me...

The mu distributions should be real rather than integers, and the size of the array to be read was also wrong.

My guess is that this didn't come up sooner because water and graphite (most commonly used) don't have this angular representation, while it showed up in poly.

This solves issue #157. 