### PR TITLE
Virtual collisions with surface tracking

### DIFF
--- a/NuclearData/ceNeutronData/aceDatabase/aceNeutronDatabase_class.f90
+++ b/NuclearData/ceNeutronData/aceDatabase/aceNeutronDatabase_class.f90
@@ -59,7 +59,8 @@ module aceNeutronDatabase_class
   !!   nuclearData {
   !!   handles {
   !!   ce { type aceNeutronDatabase; DBRC (92238 94242); ures < 1 or 0 >;
-  !!        majorant < 1 or 0 >; aceLibrary <nuclear data path> ;} }
+  !!        majorant < 1 or 0 >; aceLibrary <nuclear data path> ;} 
+  !!        #avgDist 3.141;# }
   !!
   !! Public Members:
   !!   nuclides    -> array of aceNeutronNuclides with data
@@ -773,7 +774,8 @@ contains
     character(nameLen),dimension(:),allocatable      :: nucDBRC
     real(defReal)                                    :: A, nuckT, eUpSab, eUpSabNuc, &
                                                         eLowURR, eLowUrrNuc, alpha, &
-                                                        deltakT, eUpper, eLower, kT
+                                                        deltakT, eUpper, eLower, kT, &
+                                                        temp
     real(defReal), dimension(2)                      :: sabT
     integer(shortInt), parameter :: IN_SET = 1, NOT_PRESENT = 0
     character(100), parameter :: Here = 'init (aceNeutronDatabase_class.f90)'
@@ -806,6 +808,18 @@ contains
         call nucSet % add(name, IN_SET)
       end do
     end do
+
+    ! Check for a minimum average collision distance
+    if (dict % isPresent('avgDist')) then
+      call dict % get(temp, 'avgDist')
+
+      if (temp <= ZERO) then
+        call fatalError(Here, 'Must have a finite, positive minimum average collision distance')
+      end if
+
+      self % collisionXS = ONE / temp
+
+    end if
 
     ! Get path to ACE library
     call dict % get(aceLibPath,'aceLibrary')

--- a/NuclearData/ceNeutronData/ceNeutronDatabase_inter.f90
+++ b/NuclearData/ceNeutronData/ceNeutronDatabase_inter.f90
@@ -301,10 +301,14 @@ contains
     select case(what)
 
       case (MATERIAL_XS)
-        xs = self % getTrackMatXS(p, matIdx)
+        if (matIdx == VOID_MAT) then
+          xs = self % collisionXS
+        else
+          xs = max(self % getTrackMatXS(p, matIdx), self % collisionXS)
+        end if
 
       case (MAJORANT_XS)
-        xs = self % getMajorantXS(p)
+        xs = max(self % getMajorantXS(p), self % collisionXS)
 
       case (TRACKING_XS)
 

--- a/NuclearData/nuclearDatabase_inter.f90
+++ b/NuclearData/nuclearDatabase_inter.f90
@@ -20,6 +20,10 @@ module nuclearDatabase_inter
   !! So nuclear data objects for CE or MG neutron, photons or other particles are
   !! subclasses of this type.
   !!
+  !! Public Members:
+  !!   collisionXS -> XS determining the minimum average distance to collision (to be treated as virtual).
+  !!                  ZERO by default, i.e., flight distances can be infinite in void.
+  !!
   !! Interface:
   !!   getTrackingXS -> returns XS used to sample track length
   !!   getTrackMatXS -> returns material tracking xs, which could be different from the total (e.g., with TMS)
@@ -32,6 +36,7 @@ module nuclearDatabase_inter
   !!   kill          -> return to uninitialised state, clean memory
   !!
   type, public,abstract :: nuclearDatabase
+    real(defReal)                      :: collisionXS = ZERO
   contains
     procedure(init), deferred          :: init
     procedure(activate), deferred      :: activate

--- a/docs/User Manual.rst
+++ b/docs/User Manual.rst
@@ -768,7 +768,10 @@ The **handles** definition is structured as the following: ::
       }
 
 The name of a handle has to be the same as defined in a ``physicsPackage`` under the
-keyword ``XSdata``.
+keyword ``XSdata``. The nuclear database can also be used to optionally set the minimum average
+collision distance for particles. This may be desirable in order to induce virtual collisions
+when using surface tracking in low density materials, for example. This can be done by using
+the ``avgDist`` keyword, followed by specifying the minimum average distance as desired.
 
 Otherwise, the possible **nuclear database** types allowed are:
 
@@ -786,11 +789,14 @@ from ACE files.
   to be applied.
 * majorant (*optional*, default = 1): 1 for true; 0 for false; flag to activate the
   pre-construction of a unionised majorant cross section
+* avgDist (*optional*, default = infinity): the minimum average distance until a
+  collision, which may be virtual. Used to obtain better statistics for the
+  collision estimator in low density materials, especially when using surface tracking.
   
 Example: ::
 
       ceData { type aceNuclearDatabase; aceLibrary ./myFolder/ACElib/JEF311.aceXS;
-      ures 1; DBRC (92238 94242)}
+      ures 1; DBRC (92238 94242); avgDist 32; }
 
 .. note::
    If DBRC is applied, the 0K cross section ace files of the relevant nuclides must
@@ -803,6 +809,9 @@ baseMgNeutronDatabase, used for multi-group data. In this case, the data is read
 from files provided by the user.
 
 * PN: includes a flag for anisotropy treatment. Could be ``P0`` or ``P1``
+* avgDist (*optional*, default = infinity): the minimum average distance until a
+  collision, which may be virtual. Used to obtain better statistics for the
+  collision estimator in low density materials, especially when using surface tracking.
 
 Example: ::
 


### PR DESCRIPTION
I have added a very Serpent-like feature: one can specify a minimum average flight distance before collision. The collision is then rejection sampled and can be real or virtual. This is mostly useful because it allows using surface tracking with the collision estimator to score in low density regions.

The operation is quite simple and comes mostly from the database. An 'avgDist' is input, which creates a cross section. During tracking, the maximum of the majorant/total and this cross section is used for tracking. This is then stored in cache and use for tallying as well. Beyond that, there are a few small changes to surface tracking routines.