### PR TITLE
Typo in shake/s unit

### DIFF
--- a/SharedModules/universalVariables.f90
+++ b/SharedModules/universalVariables.f90
@@ -84,8 +84,8 @@ module universalVariables
                               energyPerFission = 200.0_defReal       ! MeV
 
   ! Unit conversion
-  real(defReal), parameter :: joulesPerMeV = 1.60218e-13  ,&   ! Convert MeV to J
-                              shakesPerS   = 1.0e-8            ! Convert shakes to s
+  real(defReal), parameter :: joulesPerMeV = 1.60218e-13_defReal  ,&   ! Convert MeV to J
+                              shakesPerS   = 1.0e8_defReal             ! Convert shakes to s
 
   ! Global name variables used to define specific geometry or field types
   character(nameLen), parameter :: nameUFS  = 'uniFissSites'


### PR DESCRIPTION
It is 10^8 shake per second, not viceversa!