### PR TITLE
Fix MG majorant allocation bug

### DIFF
--- a/NuclearData/mgNeutronData/baseMgNeutron/baseMgNeutronDatabase_class.f90
+++ b/NuclearData/mgNeutronData/baseMgNeutron/baseMgNeutronDatabase_class.f90
@@ -486,6 +486,7 @@ contains
     ! TODO: Update should there be a temperature model developed for MG XSs
 
     ! Allocate majorant
+    if (allocated(self % majorant)) deallocate(self % majorant)
     allocate (self % majorant(self % nG))
 
     ! Loop over energy groups


### PR DESCRIPTION
Earlier this year a change to the physics packages mean they can also allocate majorants. To match with CE, MG now needs a check to deallocate if required. 