### PR TITLE
Fix typo in Installation.rst: SKPI_MPI → SKIP_MPI

### DIFF
--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -129,7 +129,7 @@ needs to be available::
 
 Alternatively, if one does't have access to mpi_f08 and wants to compile SCONE without MPI support::
 
-     cmake -DSKPI_MPI=YES ./..
+     cmake -DSKIP_MPI=YES ./..
 
 #. Run make and install application
 


### PR DESCRIPTION
## Summary

Fix typo in `docs/Installation.rst`: `SKPI_MPI` → `SKIP_MPI`.

Running CMAKE without MPI currently shows:

```
cmake -DSKPI_MPI=YES ./..
```

This should be:

```
cmake -DSKIP_MPI=YES ./..
```

Issue: #223