### PR TITLE
Add time delay to delayed neutrons

### DIFF
--- a/CollisionOperator/CollisionProcessors/neutronCEimp_class.f90
+++ b/CollisionOperator/CollisionProcessors/neutronCEimp_class.f90
@@ -313,7 +313,7 @@ contains
     real(defReal),dimension(3)           :: r, dir, val
     integer(shortInt)                    :: n, i
     real(defReal)                        :: wgt, rand1, E_out, mu, phi, lambda
-    real(defReal)                        :: sig_nufiss, sig_tot, k_eff, &
+    real(defReal)                        :: sig_nufiss, sig_tot, k_eff, delay, &
                                             sig_scatter, totalElastic, kT
     logical(defBool)                     :: fiss_and_implicit, keepDel
     character(100),parameter             :: Here = 'implicit (neutronCEimp_class.f90)'
@@ -391,6 +391,12 @@ contains
           pTemp % lambda = lambda
           pTemp % type = P_PRECURSOR
 
+        ! If not storing precursors, sample an emission time for
+        ! the resulting delayed neutron
+        elseif (lambda < huge(lambda)) then
+          delay = -log(p % pRNG % get()) / lambda
+          pTemp % time = p % time + delay
+
         end if
 
         call nextCycle % detain(pTemp)
@@ -456,7 +462,8 @@ contains
     real(defReal),dimension(3)           :: r, dir, val
     integer(shortInt)                    :: n, i
     real(defReal)                        :: wgt, rand1, E_out, mu, phi, lambda
-    real(defReal)                        :: sig_nufiss, sig_fiss, k_eff, kT, wD
+    real(defReal)                        :: sig_nufiss, sig_fiss, k_eff, kT, wD, &
+                                            delay
     character(100),parameter             :: Here = 'fission (neutronCEimp_class.f90)'
 
     if (.not. self % implicitSites) then
@@ -529,6 +536,12 @@ contains
         if (self % makePrec .and. lambda < huge(lambda)) then
           pTemp % lambda = lambda
           pTemp % type = P_PRECURSOR
+
+        ! If not storing precursors, sample an emission time for
+        ! the resulting delayed neutron
+        elseif (lambda < huge(lambda)) then
+          delay = -log(p % pRNG % get()) / lambda
+          pTemp % time = p % time + delay
 
         end if
 

--- a/CollisionOperator/CollisionProcessors/neutronCEstd_class.f90
+++ b/CollisionOperator/CollisionProcessors/neutronCEstd_class.f90
@@ -233,7 +233,7 @@ contains
     type(particleState)                  :: pTemp
     real(defReal),dimension(3)           :: r, dir
     integer(shortInt)                    :: n, i
-    real(defReal)                        :: wgt, w0, rand1, E_out, mu, phi
+    real(defReal)                        :: wgt, w0, rand1, E_out, mu, phi, delay
     real(defReal)                        :: sig_nufiss, sig_tot, k_eff, kT, lambda, wD
     character(100),parameter             :: Here = 'implicit (neutronCEstd_class.f90)'
 
@@ -302,6 +302,12 @@ contains
         if (self % makePrec .and. lambda < huge(lambda)) then
           pTemp % lambda = lambda
           pTemp % type = P_PRECURSOR
+
+        ! If not storing precursors, sample an emission time for
+        ! the resulting delayed neutron
+        elseif (lambda < huge(lambda)) then
+          delay = -log(p % pRNG % get()) / lambda
+          pTemp % time = p % time + delay
 
         end if
 


### PR DESCRIPTION
This adds a sampled time delay to neutrons produced by the CE collision processors which are supposed to be delayed. This doesn't matter with respect to the accuracy of eigenvalue calculations, but it is useful for a variety of tallies. It works simply by sampling the time delay given the associated precursor's decay constant.