### PR TITLE
Iterated fission probability kinetics parameters

### DIFF
--- a/CollisionOperator/CollisionProcessors/collisionProcessor_inter.f90
+++ b/CollisionOperator/CollisionProcessors/collisionProcessor_inter.f90
@@ -217,12 +217,10 @@ contains
     class(particleDungeon),intent(inout)     :: thisCycle
     class(particleDungeon),intent(inout)     :: nextCycle
     integer(shortInt)                        :: n, i
-    real(defReal)                            :: wgt, w0, rand1, k
+    real(defReal)                            :: rand1, k
     type(particleState)                      :: pTemp
 
     ! Obtain required data
-    wgt   = p % w                ! Current weight
-    w0    = p % preHistory % wgt ! Starting weight
     rand1 = p % pRNG % get()     ! Random number to sample sites
     k     = p % k_eff
 
@@ -239,6 +237,8 @@ contains
     ! Store neutrons for next cycle
     pTemp = p
     pTemp % collisionN = 0
+    pTemp % precGroup = 0
+    pTemp % lambda = huge(ONE)
     do i = 1,n
       call nextCycle % detain(pTemp, p % getIFPInfo())
       call tally % reportSpawn(N_TIME_PROD, p, pTemp)

--- a/CollisionOperator/CollisionProcessors/collisionProcessor_inter.f90
+++ b/CollisionOperator/CollisionProcessors/collisionProcessor_inter.f90
@@ -240,7 +240,7 @@ contains
     pTemp = p
     pTemp % collisionN = 0
     do i = 1,n
-      call nextCycle % detain(pTemp)
+      call nextCycle % detain(pTemp, p % getIFPInfo())
       call tally % reportSpawn(N_TIME_PROD, p, pTemp)
     end do
     p % isDead =.true.

--- a/CollisionOperator/CollisionProcessors/neutronCEimp_class.f90
+++ b/CollisionOperator/CollisionProcessors/neutronCEimp_class.f90
@@ -366,7 +366,8 @@ contains
         ! Skip if a delayed particle is produced in prompt-only mode
         if (self % neglectDelayed .and. lambda < huge(lambda)) cycle
 
-        ! If alpha, determine probability of keeping a delayed neutron
+        ! If alpha, determine probability of keeping a delayed neutron.
+        ! This lambda ratio can be negative if alpha is unconverged.
         if (abs(p % alpha) > epsilon(p % alpha)) then
           keepDel = p % pRNG % get() < lambda/(lambda + p % alpha)
           if (.not. keepDel) cycle
@@ -506,10 +507,12 @@ contains
         ! Skip if a delayed particle is produced in prompt-only mode
         if (self % neglectDelayed .and. lambda < huge(lambda)) cycle
 
-        ! If alpha, determine the weight of a delayed neutron
+        ! If alpha, determine the weight of a delayed neutron.
+        ! The lambda scaling prevents producing a negative weight
+        ! or hitting a singularity
         wD = ONE
         if (abs(p % alpha) > ZERO .and. lambda < huge(lambda)) then
-          wD = lambda/(lambda + p % alpha)
+          wD = lambda/(lambda + max(p % alpha, -lambda * 0.999))
         end if
 
         dir = rotateVector(p % dirGlobal(), mu, phi)

--- a/CollisionOperator/CollisionProcessors/neutronCEimp_class.f90
+++ b/CollisionOperator/CollisionProcessors/neutronCEimp_class.f90
@@ -311,7 +311,7 @@ contains
     type(neutronMicroXSs)                :: microXSs
     type(particleState)                  :: pTemp
     real(defReal),dimension(3)           :: r, dir, val
-    integer(shortInt)                    :: n, i
+    integer(shortInt)                    :: n, i, group
     real(defReal)                        :: wgt, rand1, E_out, mu, phi, lambda
     real(defReal)                        :: sig_nufiss, sig_tot, k_eff, &
                                             sig_scatter, totalElastic, kT
@@ -361,7 +361,7 @@ contains
       r   = p % rGlobal()
 
       do i = 1, n
-        call fission % sampleOut(mu, phi, E_out, collDat % E, p % pRNG, lambda)
+        call fission % sampleOut(mu, phi, E_out, collDat % E, p % pRNG, lambda, group)
 
         ! Skip if a delayed particle is produced in prompt-only mode
         if (self % neglectDelayed .and. lambda < huge(lambda)) cycle
@@ -385,6 +385,7 @@ contains
         pTemp % E   = E_out
         pTemp % wgt = wgt
         pTemp % collisionN = 0
+        pTemp % precGroup = group
 
         ! If storing precursors, do so when a finite lambda occurs
         if (self % makePrec .and. lambda < huge(lambda)) then
@@ -393,7 +394,7 @@ contains
 
         end if
 
-        call nextCycle % detain(pTemp)
+        call nextCycle % detain(pTemp, p % getIFPInfo())
         if (self % uniFissSites) call self % ufsField % storeFS(pTemp)
 
         ! Report birth of new particle
@@ -454,7 +455,7 @@ contains
     type(fissionCE), pointer             :: fiss
     type(particleState)                  :: pTemp
     real(defReal),dimension(3)           :: r, dir, val
-    integer(shortInt)                    :: n, i
+    integer(shortInt)                    :: n, i, group
     real(defReal)                        :: wgt, rand1, E_out, mu, phi, lambda
     real(defReal)                        :: sig_nufiss, sig_fiss, k_eff, kT, wD
     character(100),parameter             :: Here = 'fission (neutronCEimp_class.f90)'
@@ -500,7 +501,7 @@ contains
       r   = p % rGlobal()
 
       do i = 1, n
-        call fiss % sampleOut(mu, phi, E_out, collDat % E, p % pRNG, lambda)
+        call fiss % sampleOut(mu, phi, E_out, collDat % E, p % pRNG, lambda, group)
 
         ! Skip if a delayed particle is produced in prompt-only mode
         if (self % neglectDelayed .and. lambda < huge(lambda)) cycle
@@ -524,6 +525,7 @@ contains
         pTemp % E   = E_out
         pTemp % wgt = wgt * wD
         pTemp % collisionN = 0
+        pTemp % precGroup = group
 
         ! If storing precursors, do so when a finite lambda occurs
         if (self % makePrec .and. lambda < huge(lambda)) then
@@ -532,7 +534,7 @@ contains
 
         end if
 
-        call nextCycle % detain(pTemp)
+        call nextCycle % detain(pTemp, p % getIFPInfo())
         if (self % uniFissSites) call self % ufsField % storeFS(pTemp)
 
         ! Report birth of new particle

--- a/CollisionOperator/CollisionProcessors/neutronCEstd_class.f90
+++ b/CollisionOperator/CollisionProcessors/neutronCEstd_class.f90
@@ -279,9 +279,11 @@ contains
         if (self % neglectDelayed .and. lambda < huge(lambda)) cycle
 
         ! If alpha, determine the weight of a delayed neutron
+        ! The lambda scaling prevents producing a negative weight
+        ! or hitting a singularity
         wD = ONE
-        if (abs(p % alpha) > epsilon(p % alpha) .and. lambda < huge(lambda)) then
-          wD = lambda/(lambda + p % alpha)
+        if (abs(p % alpha) > ZERO .and. lambda < huge(lambda)) then
+          wD = lambda/(lambda + max(p % alpha, -lambda * 0.99))
         end if
 
         dir = rotateVector(p % dirGlobal(), mu, phi)

--- a/CollisionOperator/CollisionProcessors/neutronCEstd_class.f90
+++ b/CollisionOperator/CollisionProcessors/neutronCEstd_class.f90
@@ -232,7 +232,7 @@ contains
     type(neutronMicroXSs)                :: microXSs
     type(particleState)                  :: pTemp
     real(defReal),dimension(3)           :: r, dir
-    integer(shortInt)                    :: n, i
+    integer(shortInt)                    :: n, i, group
     real(defReal)                        :: wgt, w0, rand1, E_out, mu, phi
     real(defReal)                        :: sig_nufiss, sig_tot, k_eff, kT, lambda, wD
     character(100),parameter             :: Here = 'implicit (neutronCEstd_class.f90)'
@@ -273,7 +273,7 @@ contains
       r   = p % rGlobal()
 
       do i = 1, n
-        call fission % sampleOut(mu, phi, E_out, collDat % E, p % pRNG, lambda)
+        call fission % sampleOut(mu, phi, E_out, collDat % E, p % pRNG, lambda, group)
 
         ! Skip if a delayed particle is produced in prompt-only mode
         if (self % neglectDelayed .and. lambda < huge(lambda)) cycle
@@ -297,6 +297,7 @@ contains
         pTemp % E   = E_out
         pTemp % wgt = wgt * wD
         pTemp % collisionN = 0
+        pTemp % precGroup = group
 
         ! If storing precursors, do so when a finite lambda occurs
         if (self % makePrec .and. lambda < huge(lambda)) then
@@ -305,7 +306,7 @@ contains
 
         end if
 
-        call nextCycle % detain(pTemp)
+        call nextCycle % detain(pTemp, p % getIFPInfo())
 
         ! Report birth of new particle
         call tally % reportSpawn(N_FISSION, p, pTemp)

--- a/DataStructures/heapQueue_class.f90
+++ b/DataStructures/heapQueue_class.f90
@@ -138,8 +138,11 @@ contains
       ! We need to consider the case where there is only one child in a node
       ! (can happen when the size is even). If child is the last element it is the
       ! node with no sibling
-      if (child /= self % size .and. self % heap(child) < self % heap(child + 1)) then
-        child = child + 1
+      ! This was split into nested conditionals to prevent out-of-bounds access.
+      if (child /= self % size) then
+        if (self % heap(child) < self % heap(child + 1)) then
+          child = child + 1
+        end if
       end if
 
       ! If the parent is larger than the larger child we are done

--- a/InputFiles/Benchmarks/MCNP/BIGTEN
+++ b/InputFiles/Benchmarks/MCNP/BIGTEN
@@ -11,9 +11,11 @@ type eigenPhysicsPackage;
 
 pop      200000;
 active 100;
-inactive 200;
+inactive 100;
 XSdata   ceData;
 dataType ce;
+outputFile BIGTEN;
+sizeIFP 10;
 
 collisionOperator { neutronCE {type neutronCEstd;}
                   }
@@ -25,10 +27,11 @@ inactiveTally {
               }
 
 activeTally  {
-                display (keff);
+                display (keff ifp);
                 norm fiss;
                 normVal 100.0;
                 keff { type keffAnalogClerk;}
+                ifp  { type kineticIFPClerk;}
                 fiss { type collisionClerk; response (fiss); fiss {type macroResponse; MT -6;}}
                 flux { type collisionClerk;
                        map { type energyMap; grid log; min 0.001; max 20; N 300;}

--- a/InputFiles/Benchmarks/MCNP/Flattop23
+++ b/InputFiles/Benchmarks/MCNP/Flattop23
@@ -9,9 +9,11 @@ type eigenPhysicsPackage;
 
 pop      200000;
 active 100;
-inactive 200;
+inactive 100;
 XSdata   ceData;
 dataType ce;
+sizeIFP 10;
+outputFile Flattop23;
 
 collisionOperator { neutronCE {type neutronCEstd;}
                   }
@@ -23,10 +25,11 @@ inactiveTally {
               }
 
 activeTally  {
-                display (keff);
+                display (keff ifp);
                 norm fiss;
                 normVal 100.0;
                 keff { type keffAnalogClerk;}
+                ifp  { type kineticIFPClerk;}
                 fiss { type collisionClerk; response (fiss); fiss {type macroResponse; MT -6;}}
                 flux { type collisionClerk;
                        map { type energyMap; grid log; min 0.001; max 20; N 300;}

--- a/InputFiles/Benchmarks/MCNP/Flattop25
+++ b/InputFiles/Benchmarks/MCNP/Flattop25
@@ -1,5 +1,5 @@
 
-// MCNP benchmark case Flattop-25
+// MCNP benchmark case Flattop-25 (or Topsy)
 //
 // Highly enriched uranium (HEU) sphere (to 6.1156cm radius) with uranium reflector (to 24.1242 radius)
 // Benchmark keff = 1.0000 +/- 0.0030
@@ -9,9 +9,11 @@ type eigenPhysicsPackage;
 
 pop      200000;
 active 100;
-inactive 200;
+inactive 100;
 XSdata   ceData;
 dataType ce;
+sizeIFP 10;
+outputFile Flattop25;
 
 collisionOperator { neutronCE {type neutronCEstd;}
                   }
@@ -23,10 +25,11 @@ inactiveTally {
               }
 
 activeTally  {
-                display (keff);
+                display (keff ifp);
                 norm fiss;
                 normVal 100.0;
                 keff { type keffAnalogClerk;}
+                ifp  { type kineticIFPClerk;}
                 fiss { type collisionClerk; response (fiss); fiss {type macroResponse; MT -6;}}
                 flux { type collisionClerk;
                        map { type energyMap; grid log; min 0.001; max 20; N 300;}

--- a/InputFiles/Benchmarks/MCNP/FlattopPu
+++ b/InputFiles/Benchmarks/MCNP/FlattopPu
@@ -1,5 +1,5 @@
 
-// MCNP benchmark case Flattop-Pu
+// MCNP benchmark case Flattop-Pu (or Popsy)
 //
 // Pu sphere (to 4.5332cm radius) with uranium reflector (to 24.1420cm radius)
 // Benchmark keff = 1.0000 +/- 0.0014
@@ -9,9 +9,11 @@ type eigenPhysicsPackage;
 
 pop      200000;
 active 100;
-inactive 200;
+inactive 100;
 XSdata   ceData;
 dataType ce;
+outputFile FlattopPu;
+sizeIFP 10;
 
 collisionOperator { neutronCE {type neutronCEstd;}
                   }
@@ -23,10 +25,11 @@ inactiveTally {
               }
 
 activeTally  {
-                display (keff);
+                display (keff ifp);
                 norm fiss;
                 normVal 100.0;
                 keff { type keffAnalogClerk;}
+                ifp  { type kineticIFPClerk;}
                 fiss { type collisionClerk; response (fiss); fiss {type macroResponse; MT -6;}}
                 flux { type collisionClerk;
                        map { type energyMap; grid log; min 0.001; max 20; N 300;}

--- a/InputFiles/Benchmarks/MCNP/Godiva
+++ b/InputFiles/Benchmarks/MCNP/Godiva
@@ -9,9 +9,11 @@ type eigenPhysicsPackage;
 
 pop      200000;
 active 100;
-inactive 200;
+inactive 100;
 XSdata   ceData;
 dataType ce;
+sizeIFP 10;
+outputFile Godiva;
 
 collisionOperator { neutronCE {type neutronCEstd;}
                   }
@@ -23,10 +25,11 @@ inactiveTally {
               }
 
 activeTally  {
-                display (keff);
+                display (keff ifp);
                 norm fiss;
                 normVal 100.0;
                 keff { type keffAnalogClerk;}
+                ifp  { type kineticIFPClerk;}
                 fiss { type collisionClerk; response (fiss); fiss {type macroResponse; MT -6;}}
                 flux { type collisionClerk;
                        map { type energyMap; grid log; min 0.001; max 20; N 300;}

--- a/InputFiles/Benchmarks/MCNP/Jezebel
+++ b/InputFiles/Benchmarks/MCNP/Jezebel
@@ -9,9 +9,11 @@ type eigenPhysicsPackage;
 
 pop      200000;
 active 100;
-inactive 200;
+inactive 100;
 XSdata   ceData;
 dataType ce;
+sizeIFP 10;
+outputFile Jezebel;
 
 collisionOperator { neutronCE {type neutronCEstd;}
 
@@ -24,10 +26,11 @@ inactiveTally {
               }
 
 activeTally  {
-                display (keff);
+                display (keff ifp);
                 norm fiss;
                 normVal 100.0;
                 keff { type keffAnalogClerk;}
+                ifp  { type kineticIFPClerk;}
                 fiss { type collisionClerk; response (fiss); fiss {type macroResponse; MT -6;}}
                 flux { type collisionClerk;
                        map { type energyMap; grid log; min 0.001; max 20; N 300;}

--- a/NuclearData/Reactions/thermalScattReactionCE/thermalScatterElastic_class.f90
+++ b/NuclearData/Reactions/thermalScattReactionCE/thermalScatterElastic_class.f90
@@ -164,7 +164,7 @@ contains
   !!
   !! See uncorrelatedReactionCE for details
   !!
-  subroutine sampleOut(self, mu, phi, E_out, E_in, rand, lambda)
+  subroutine sampleOut(self, mu, phi, E_out, E_in, rand, lambda, group)
     class(thElasticScatter), intent(in) :: self
     real(defReal), intent(out)               :: mu
     real(defReal), intent(out)               :: phi
@@ -172,6 +172,7 @@ contains
     real(defReal), intent(in)                :: E_in
     class(RNG), intent(inout)                :: rand
     real(defReal), intent(out), optional     :: lambda
+    integer(shortInt), intent(out), optional :: group
     real(defReal), dimension(:), allocatable :: prob
     real(defReal)        :: E1, E2, f, mu_l1k, mu1, mu2, mu3, muLeft, muRight, r
     integer(shortInt)    :: l1, l2, k, i
@@ -257,8 +258,9 @@ contains
     ! Sample phi
     phi = rand % get() * TWO_PI
 
-    ! Only prompt particles. Set delay
+    ! Only prompt particles. Set delay and group
     if(present(lambda)) lambda = huge(lambda)
+    if(present(group)) group = 0
 
   end subroutine sampleOut
 

--- a/NuclearData/Reactions/thermalScattReactionCE/thermalScatterInelastic_class.f90
+++ b/NuclearData/Reactions/thermalScattReactionCE/thermalScatterInelastic_class.f90
@@ -201,14 +201,15 @@ contains
   !!
   !! See uncorrelatedReactionCE for details
   !!
-  subroutine sampleOut(self, mu, phi, E_out, E_in, rand, lambda)
-    class(thInelasticScatter), intent(in) :: self
-    real(defReal), intent(out)            :: mu
-    real(defReal), intent(out)            :: phi
-    real(defReal), intent(out)            :: E_out
-    real(defReal), intent(in)             :: E_in
-    class(RNG), intent(inout)             :: rand
-    real(defReal), intent(out), optional  :: lambda
+  subroutine sampleOut(self, mu, phi, E_out, E_in, rand, lambda, group)
+    class(thInelasticScatter), intent(in)    :: self
+    real(defReal), intent(out)               :: mu
+    real(defReal), intent(out)               :: phi
+    real(defReal), intent(out)               :: E_out
+    real(defReal), intent(in)                :: E_in
+    class(RNG), intent(inout)                :: rand
+    real(defReal), intent(out), optional     :: lambda
+    integer(shortInt), intent(out), optional :: group
     real(defReal)     :: E_min, E_max
     real(defReal)     :: E1, E2, f, eps
     real(defReal)     :: mu_ljk, mu1, mu2, mu3, muLeft, muRight
@@ -302,8 +303,9 @@ contains
     ! Sample phi
     phi = rand % get() * TWO_PI
 
-    ! Only prompt particles. Set delay
+    ! Only prompt particles. Set delay and group
     if(present(lambda)) lambda = huge(lambda)
+    if(present(group)) group = 0
 
   end subroutine sampleOut
 

--- a/NuclearData/Reactions/uncorrelatedReactionCE/elasticNeutronScatter_class.f90
+++ b/NuclearData/Reactions/uncorrelatedReactionCE/elasticNeutronScatter_class.f90
@@ -165,7 +165,7 @@ contains
   !!
   !! See uncorrelatedReactionCE for details
   !!
-  subroutine sampleOut(self, mu, phi, E_out, E_in, rand, lambda)
+  subroutine sampleOut(self, mu, phi, E_out, E_in, rand, lambda, group)
     class(elasticNeutronScatter), intent(in) :: self
     real(defReal), intent(out)               :: mu
     real(defReal), intent(out)               :: phi
@@ -173,6 +173,7 @@ contains
     real(defReal), intent(in)                :: E_in
     class(RNG), intent(inout)                :: rand
     real(defReal), intent(out), optional     :: lambda
+    integer(shortInt), intent(out), optional :: group
 
     ! Set energy
     E_out = E_in
@@ -189,8 +190,9 @@ contains
     ! Sample phi
     phi = rand % get() * TWO_PI
 
-    ! Only prompt particles. Set delay
+    ! Only prompt particles. Set delay and group
     if(present(lambda)) lambda = huge(lambda)
+    if(present(group)) group = 0
 
   end subroutine sampleOut
 

--- a/NuclearData/Reactions/uncorrelatedReactionCE/fissionCE_class.f90
+++ b/NuclearData/Reactions/uncorrelatedReactionCE/fissionCE_class.f90
@@ -239,16 +239,17 @@ contains
   !!
   !! See uncorrelatedReactionCE for details
   !!
-  subroutine sampleOut(self, mu, phi, E_out, E_in, rand, lambda)
-    class(fissionCE), intent(in)         :: self
-    real(defReal), intent(out)           :: mu
-    real(defReal), intent(out)           :: phi
-    real(defReal), intent(out)           :: E_out
-    real(defReal), intent(in)            :: E_in
-    class(RNG), intent(inout)            :: rand
-    real(defReal), intent(out), optional :: lambda
-    real(defReal)                        :: p_del, r1, r2
-    integer(shortInt)                    :: i, N
+  subroutine sampleOut(self, mu, phi, E_out, E_in, rand, lambda, group)
+    class(fissionCE), intent(in)             :: self
+    real(defReal), intent(out)               :: mu
+    real(defReal), intent(out)               :: phi
+    real(defReal), intent(out)               :: E_out
+    real(defReal), intent(in)                :: E_in
+    class(RNG), intent(inout)                :: rand
+    real(defReal), intent(out), optional     :: lambda
+    integer(shortInt), intent(out), optional :: group
+    real(defReal)                            :: p_del, r1, r2
+    integer(shortInt)                        :: i, N
     character(100),parameter :: Here = 'sample (fissionCE_class.f90)'
 
     ! Sample mu
@@ -268,6 +269,7 @@ contains
     if (r1 > p_del) then ! Prompt emission
       E_out = self % eLawPrompt % sample(E_in, rand)
       if (present(lambda)) lambda = huge(lambda)
+      if (present(group)) group = 0
 
     else ! Delayed emission
       r2 = rand % get()
@@ -278,6 +280,7 @@ contains
         if (r2 < ZERO) then
           E_out = self % delayed(i) % eLaw % sample(E_in, rand)
           if (present(lambda)) lambda = self % delayed(i) % lambda
+          if (present(group)) group = i
           return
 
         end if
@@ -287,6 +290,7 @@ contains
       N = size(self % delayed)
       E_out = self % delayed(N) % eLaw % sample(E_in, rand)
       if (present(lambda)) lambda = self % delayed(N) % lambda
+      if (present(group)) group = N
 
     end if
   end subroutine sampleOut

--- a/NuclearData/Reactions/uncorrelatedReactionCE/neutronScatter_class.f90
+++ b/NuclearData/Reactions/uncorrelatedReactionCE/neutronScatter_class.f90
@@ -194,7 +194,7 @@ contains
   !!
   !! See uncorrelatedReactionCE for details
   !!
-  subroutine sampleOut(self, mu, phi, E_out, E_in, rand, lambda)
+  subroutine sampleOut(self, mu, phi, E_out, E_in, rand, lambda, group)
     class(neutronScatter), intent(in) :: self
     real(defReal), intent(out)               :: mu
     real(defReal), intent(out)               :: phi
@@ -202,6 +202,7 @@ contains
     real(defReal), intent(in)                :: E_in
     class(RNG), intent(inout)                :: rand
     real(defReal), intent(out), optional     :: lambda
+    integer(shortInt), intent(out), optional :: group
 
     ! Sample energy an angle
     if (self % correlated) then
@@ -220,8 +221,9 @@ contains
     ! Sample phi
     phi = rand % get() * TWO_PI
 
-    ! Only prompt particles. Set delay
+    ! Only prompt particles. Set delay and group
     if (present(lambda)) lambda = huge(lambda)
+    if (present(group)) group = 0
 
   end subroutine sampleOut
 

--- a/NuclearData/Reactions/uncorrelatedReactionCE/pureCapture_class.f90
+++ b/NuclearData/Reactions/uncorrelatedReactionCE/pureCapture_class.f90
@@ -130,14 +130,15 @@ contains
   !!
   !! See uncorrelatedReactionCE for details
   !!
-  subroutine sampleOut(self, mu, phi, E_out, E_in, rand, lambda)
-    class(pureCapture), intent(in)         :: self
-    real(defReal), intent(out)             :: mu
-    real(defReal), intent(out)             :: phi
-    real(defReal), intent(out)             :: E_out
-    real(defReal), intent(in)              :: E_in
-    class(RNG), intent(inout)              :: rand
-    real(defReal), intent(out), optional   :: lambda
+  subroutine sampleOut(self, mu, phi, E_out, E_in, rand, lambda, group)
+    class(pureCapture), intent(in)           :: self
+    real(defReal), intent(out)               :: mu
+    real(defReal), intent(out)               :: phi
+    real(defReal), intent(out)               :: E_out
+    real(defReal), intent(in)                :: E_in
+    class(RNG), intent(inout)                :: rand
+    real(defReal), intent(out), optional     :: lambda
+    integer(shortInt), intent(out), optional :: group
 
     E_out = E_in
     mu = ONE
@@ -145,6 +146,7 @@ contains
 
     ! Default to the prompt particle
     if(present(lambda)) lambda = huge(lambda)
+    if(present(group)) group = 0
 
   end subroutine sampleOut
 

--- a/NuclearData/Reactions/uncorrelatedReactionCE_inter.f90
+++ b/NuclearData/Reactions/uncorrelatedReactionCE_inter.f90
@@ -131,12 +131,13 @@ module uncorrelatedReactionCE_inter
     !!   E_in [in]    -> incident particle energy [MeV]
     !!   rand [inout] -> Random number generator for samples
     !!   lambda [out] -> Optional. Delay rate of the emission [1/s]
+    !!   group [out]  -> Optional. Delay group of emission. Mainly for fission.
     !!
     !! Errors:
     !!   If E_in is out of bounds or invalid (e.g.-ve) fatalError is returned
     !!
-    subroutine sampleOut(self, mu, phi, E_out, E_in, rand, lambda)
-      import :: defReal, uncorrelatedReactionCE, RNG
+    subroutine sampleOut(self, mu, phi, E_out, E_in, rand, lambda, group)
+      import :: defReal, shortInt, uncorrelatedReactionCE, RNG
       class(uncorrelatedReactionCE), intent(in) :: self
       real(defReal), intent(out)                :: mu
       real(defReal), intent(out)                :: phi
@@ -144,6 +145,7 @@ module uncorrelatedReactionCE_inter
       real(defReal), intent(in)                 :: E_in
       class(RNG), intent(inout)                 :: rand
       real(defReal), intent(out),optional       :: lambda
+      integer(shortInt), intent(out), optional  :: group
     end subroutine sampleOut
 
     !!

--- a/ParticleObjects/particleDungeon_class.f90
+++ b/ParticleObjects/particleDungeon_class.f90
@@ -3,7 +3,7 @@ module particleDungeon_class
   use numPrecision
   use errors_mod,            only : fatalError
   use genericProcedures,     only : numToChar, swap
-  use particle_class,        only : particle, particleStateData, particleState
+  use particle_class,        only : particle, particleStateData, particleState, infoIFP
   use RNG_class,             only : RNG
   use heapQueue_class,       only : heapQueue
 
@@ -25,6 +25,9 @@ module particleDungeon_class
   !! Similar structures are referred to as:
   !! Store: MONK and Serpent(?)
   !! Fission Bank: OpenMC and MCNP(?)
+  !!
+  !! Also optionally stores particle ancestry information to be used for iterated fission probability
+  !! calculations, e.g., of kinetic parameters.
   !!
   !! NOTE INCONSISTENT DEFINITIONS
   !! ****
@@ -65,18 +68,24 @@ module particleDungeon_class
   !!     setSize(n)        -> sizes dungeon to have n dummy particles for ease of overwriting
   !!     setTime(t)        -> sets all particles to being at the same point in time
   !!     printToFile(name) -> prints population in ASCII format to file "name"
+  !!     updateAncestry    -> updates ancestor info from a previous cycle dungeon
   !!
   !!   Build procedures:
-  !!     init(maxSize)     -> allocate space to store maximum of maxSize particles
-  !!     kill()            -> return to uninitialised state
+  !!     init(maxSize, sizeIFP) -> allocate space to store maximum of maxSize particles.
+  !!                               Optionally also allocate storage for IFP info.
+  !!     kill()                 -> return to uninitialised state
   !!
   type, public :: particleDungeon
     private
     real(defReal), public :: k_eff = ONE ! k-eff for fission site generation rate normalisation
     integer(shortInt)     :: pop = 0     ! Current population size of the dungeon
+    integer(shortInt)     :: sizeIFP = 0 ! Number of generations of info stored for IFP calculations
 
     ! Storage space
     type(particleState), dimension(:), allocatable, public :: prisoners
+    real(defReal), dimension(:), allocatable, public       :: ancestorLifetimes
+    real(defReal), dimension(:), allocatable, public       :: ancestorWeights
+    integer(shortInt), dimension(:), allocatable, public   :: ancestorDelayedGroups
 
   contains
     !! Build procedures
@@ -107,6 +116,11 @@ module particleDungeon_class
     procedure  :: setSize
     procedure  :: printToFile
     procedure  :: sortByBroodID
+    
+    ! IFP-related data
+    procedure  :: hasIFPData
+    procedure  :: updateAncestry
+    procedure  :: getIFPValues
 
     !! Precursor procedures
     procedure  :: precursorCombing
@@ -119,6 +133,12 @@ module particleDungeon_class
     procedure, private :: replace_particle
     procedure, private :: replace_particleState
     procedure, private :: loadBalancing
+    
+    ! Private procedures for IFP
+    procedure, private :: replaceIFP
+    procedure, private :: setSizeAncestry
+    procedure, private :: loadBalanceIFPSend
+    procedure, private :: loadBalanceIFPReceive
 
   end type particleDungeon
 
@@ -127,13 +147,29 @@ contains
   !!
   !! Allocate space for the particles
   !!
-  subroutine init(self,maxSize)
-    class(particleDungeon), intent(inout) :: self
-    integer(shortInt), intent(in)         :: maxSize
+  subroutine init(self, maxSize, sizeIFP)
+    class(particleDungeon), intent(inout)   :: self
+    integer(shortInt), intent(in)           :: maxSize
+    integer(shortInt), intent(in), optional :: sizeIFP
 
     if (allocated(self % prisoners)) deallocate(self % prisoners)
     allocate(self % prisoners(maxSize))
     self % pop    = 0
+
+    if (present(sizeIFP)) then
+      if (sizeIFP > 0) then
+        self % sizeIFP = sizeIFP
+        if (allocated(self % ancestorWeights)) deallocate(self % ancestorWeights)
+        if (allocated(self % ancestorLifetimes)) deallocate(self % ancestorLifetimes)
+        if (allocated(self % ancestorDelayedGroups)) deallocate(self % ancestorDelayedGroups)
+        allocate(self % ancestorWeights(sizeIFP * maxSize))
+        allocate(self % ancestorLifetimes(sizeIFP * maxSize))
+        allocate(self % ancestorDelayedGroups(sizeIFP * maxSize))
+        self % ancestorWeights = ZERO
+        self % ancestorLifetimes = ZERO
+        self % ancestorDelayedGroups = 0
+      end if
+    end if
 
   end subroutine init
 
@@ -145,19 +181,24 @@ contains
 
     ! Reset settings
     self % pop = 0
+    self % sizeIFP = 0
 
     ! Deallocate memeory
     if (allocated(self % prisoners)) deallocate(self % prisoners)
+    if (allocated(self % ancestorWeights)) deallocate(self % ancestorWeights)
+    if (allocated(self % ancestorLifetimes)) deallocate(self % ancestorLifetimes)
+    if (allocated(self % ancestorDelayedGroups)) deallocate(self % ancestorDelayedGroups)
 
   end subroutine kill
 
   !!
   !! Store particle in the dungeon
   !!
-  subroutine detain_particle(self,p)
+  subroutine detain_particle(self, p, ifpData)
     class(particleDungeon), intent(inout) :: self
     class(particle), intent(in)           :: p
-    integer(shortInt)                     :: pop
+    type(infoIFP), intent(in), optional   :: ifpData
+    integer(shortInt)                     :: pop, idx
     character(100),parameter              :: Here = 'detain_particle (particleDungeon_class.f90)'
 
     !$omp atomic capture
@@ -176,15 +217,24 @@ contains
     ! Load new particle
     self % prisoners(pop) = p
 
+    ! Load IFP data
+    if (present(ifpData) .and. self % hasIFPData()) then
+      idx = (pop - 1) * self % sizeIFP + 1
+      self % ancestorWeights(idx) = ifpData % weight
+      self % ancestorLifetimes(idx) = ifpData % lifetime
+      self % ancestorDelayedGroups(idx) = ifpData % precGroup
+    end if
+
   end subroutine detain_particle
 
   !!
   !! Store particle in the dungeon with a critical operation
   !!
-  subroutine detainCritical_particle(self,p)
+  subroutine detainCritical_particle(self, p, ifpData)
     class(particleDungeon), intent(inout) :: self
     class(particle), intent(in)           :: p
-    integer(shortInt)                     :: pop
+    type(infoIFP), intent(in), optional   :: ifpData
+    integer(shortInt)                     :: pop, idx
     character(100),parameter              :: Here = 'detainCritical_particle (particleDungeon_class.f90)'
 
     !$omp critical (dungeon)
@@ -201,6 +251,14 @@ contains
 
     ! Load new particle
     self % prisoners(pop) = p
+    
+    ! Load IFP data
+    if (present(ifpData) .and. self % hasIFPData()) then
+      idx = (pop - 1) * self % sizeIFP + 1
+      self % ancestorWeights(idx) = ifpData % weight
+      self % ancestorLifetimes(idx) = ifpData % lifetime
+      self % ancestorDelayedGroups(idx) = ifpData % precGroup
+    end if
     !$omp end critical (dungeon)
 
   end subroutine detainCritical_particle
@@ -208,10 +266,11 @@ contains
   !!
   !! Store phaseCoord in the dungeon
   !!
-  subroutine detain_particleState(self,p_state)
+  subroutine detain_particleState(self, p_state, ifpData)
     class(particleDungeon), intent(inout) :: self
     type(particleState), intent(in)       :: p_state
-    integer(shortInt)                     :: pop
+    type(infoIFP), intent(in), optional   :: ifpData
+    integer(shortInt)                     :: pop, idx
     character(100), parameter    :: Here = 'detain_particleState (particleDungeon_class.f90)'
 
     ! Increase population
@@ -230,15 +289,24 @@ contains
     ! Load new particle
     self % prisoners(pop) = p_state
 
+    ! Load IFP data
+    if (present(ifpData) .and. self % hasIFPData()) then
+      idx = (pop - 1) * self % sizeIFP + 1
+      self % ancestorWeights(idx) = ifpData % weight
+      self % ancestorLifetimes(idx) = ifpData % lifetime
+      self % ancestorDelayedGroups(idx) = ifpData % precGroup
+    end if
+
   end subroutine detain_particleState
 
   !!
   !! Store phaseCoord in the dungeon with a critical operation
   !!
-  subroutine detainCritical_particleState(self,p_state)
+  subroutine detainCritical_particleState(self, p_state, ifpData)
     class(particleDungeon), intent(inout) :: self
     type(particleState), intent(in)       :: p_state
-    integer(shortInt)                     :: pop
+    type(infoIFP), intent(in), optional   :: ifpData
+    integer(shortInt)                     :: pop, idx
     character(100), parameter    :: Here = 'detainCritical_particleState (particleDungeon_class.f90)'
 
     ! Increase population
@@ -255,6 +323,14 @@ contains
 
     ! Load new particle
     self % prisoners(pop) = p_state
+
+    ! Load IFP data
+    if (present(ifpData) .and. self % hasIFPData()) then
+      idx = (pop - 1) * self % sizeIFP + 1
+      self % ancestorWeights(idx) = ifpData % weight
+      self % ancestorLifetimes(idx) = ifpData % lifetime
+      self % ancestorDelayedGroups(idx) = ifpData % precGroup
+    end if
     !$omp end critical (dungeon)
 
   end subroutine detainCritical_particleState
@@ -341,6 +417,7 @@ contains
     self % prisoners(idx) = p
 
   end subroutine replace_particleState
+
 
   !!
   !! Copy particle from a location inside the dungeon
@@ -546,6 +623,11 @@ contains
         if (i /= keepers(i)) self % prisoners(i) = self % prisoners(keepers(i))
       end do
 
+      ! Update IFP data
+      if (self % hasIFPData()) then
+        call self % replaceIFP(keepers(1:count))
+      end if
+
       ! Update population number
       self % pop = count
 
@@ -555,10 +637,16 @@ contains
       totSites     = excess + totPop
       n_copies     = -excess / totSites
       n_duplicates = modulo(-excess, totSites)
+      
+      ! Keepers array only used here for permuting IFP data
+      allocate(keepers(totPop))
+      keepers = 0
+      keepers(1:self % pop) = [(j, j = 1, self % pop)]
 
       ! Copy all the particles the number of times needed
       do i = 1, n_copies
         self % prisoners(self % pop * i + 1 : self % pop * (i + 1)) = self % prisoners(1:self % pop)
+        keepers(self % pop * i + 1 : self % pop * (i + 1)) = [(j, j = 1, self % pop)]
       end do
 
       ! Loop over population to duplicate from
@@ -571,9 +659,15 @@ contains
           if (rankRand % get() <= threshold) then
             count = count + 1
             self % prisoners(count) = self % prisoners(i)
+            keepers(count) = i
           end if
         end do
 
+      end if
+
+      ! Update IFP data
+      if (self % hasIFPData()) then
+        call self % replaceIFP(keepers)
       end if
 
       ! Update population number
@@ -581,7 +675,7 @@ contains
 
       ! Determine the maximum brood ID and sort the dungeon again for MPI reproducibility
       maxBroodID = maxval(self % prisoners(1:self % pop) % broodID)
-      call self % sortByBroodID(maxbroodID)
+      call self % sortByBroodID(maxBroodID)
 
     end if
 
@@ -645,6 +739,12 @@ contains
       ! Send particles from the end of the dungeon to the rank above
       dataBuffer = self % prisoners(self % pop - excess + 1 : self % pop)
       call mpi_send(dataBuffer, excess, MPI_PARTICLE_STATE, rank + 1, rank, MPI_COMM_WORLD, error)
+
+      ! Likewise send IFP info
+      if (self % hasIFPData()) then
+        call self % loadBalanceIFPSend(excess, rank + 1, rank, .false.)
+      end if
+
       self % pop = self % pop - excess
 
     elseif (excess < 0) then
@@ -658,6 +758,12 @@ contains
         stateBuffer(i) = dataBuffer(i)
       end do
       self % prisoners(self % pop + 1 : self % pop + excess) = stateBuffer
+
+      ! Likewise receive IFP info
+      if (self % hasIFPData()) then
+        call self % loadBalanceIFPReceive(excess, rank + 1, rank + 1, .false.)
+      end if
+
       self % pop = self % pop + excess
 
     end if
@@ -677,6 +783,12 @@ contains
 
       ! Move the remaining particles to the beginning of the dungeon
       self % prisoners(1 : self % pop - excess) = self % prisoners(excess + 1 : self % pop)
+      
+      ! Likewise send IFP info
+      if (self % hasIFPData()) then
+        call self % loadBalanceIFPSend(excess, rank - 1, rank, .true.)
+      end if
+      
       self % pop = self % pop - excess
 
     elseif (excess > 0) then
@@ -690,6 +802,12 @@ contains
       end do
       self % prisoners(excess + 1 : self % pop + excess) = self % prisoners(1 : self % pop)
       self % prisoners(1 : excess) = stateBuffer
+      
+      ! Likewise receive IFP info
+      if (self % hasIFPData()) then
+        call self % loadBalanceIFPReceive(excess, rank - 1, rank - 1, .true.)
+      end if
+
       self % pop = self % pop + excess
 
     end if
@@ -788,13 +906,14 @@ contains
     real(defReal)                         :: tooth0, wAv
     real(defReal)                         :: nextTooth, curWeight
     type(particleState), dimension(N)     :: newPrisoners
+    integer(shortInt), dimension(N)       :: newIdxs
     character(100), parameter :: Here =' combing (particleDungeon_class.f90)'
 
     ! Protect against invalid N
-    if( N > size(self % prisoners)) then
+    if(N > size(self % prisoners)) then
       call fatalError(Here,'Requested size: '//numToChar(N) //&
                            'is greater then max size: '//numToChar(size(self % prisoners)))
-    else if ( N <= 0 ) then
+    else if (N <= 0) then
       call fatalError(Here,'Requested size: '//numToChar(N) //' is not +ve')
     end if
 
@@ -822,6 +941,7 @@ contains
       end do
 
       ! When a particle has been found
+      newIdxs(i) = j
       newPrisoners(i) = self % prisoners(j)    ! Add to new array
       newPrisoners(i) % wgt = wAv              ! Update weight
     end do
@@ -835,6 +955,11 @@ contains
       call self % replace(newPrisoners(i), i)
     end do
     !$omp end parallel do
+      
+    ! Also replace IFP info
+    if (self % hasIFPData()) then
+      call self % replaceIFP(newIdxs)
+    end if
 
   end subroutine combing
 
@@ -855,6 +980,7 @@ contains
     type(particle), save                     :: p
     integer(shortInt)                        :: i, j
     type(particleState), dimension(N)        :: newPrecursors
+    integer(shortInt), dimension(N)          :: newIdxs
     real(defReal), dimension(self % pop)     :: expDelayedWgts, expFactors
     real(defReal)                            :: uAv, tooth0
     real(defReal)                            :: nextTooth, curExpDelayedWgt
@@ -898,6 +1024,7 @@ contains
       end do
 
       ! When a particle has been found...
+      newIdxs(i) = j
       newPrecursors(i) = self % prisoners(j)       ! Add to new array
       newPrecursors(i) % wgt = uAv / expFactors(j) ! Update weight from timed weight
     end do
@@ -908,9 +1035,14 @@ contains
     ! Replace the particle at each index with the new particles
     !$omp parallel do
     do i = 1, N
-      call self % replace_particleState(newPrecursors(i), i)
+      call self % replace(newPrecursors(i), i)
     end do
     !$omp end parallel do
+    
+    ! Also replace IFP info
+    if (self % hasIFPData()) then
+      call self % replaceIFP(newIdxs)
+    end if
 
   end subroutine precursorCombing
 
@@ -956,6 +1088,11 @@ contains
       count(id) = count(id) + 1
       perm(loc) = i
     end do
+    
+    ! Permute IFP data if present
+    if (self % hasIFPData()) then
+      call self % replaceIFP(perm)
+    end if
 
     ! Permute particles
     do i = 1, self % pop
@@ -1001,7 +1138,7 @@ contains
   end subroutine setTime
 
   !!
-  !! Kill or particles in the dungeon
+  !! Kill all particles in the dungeon
   !!
   pure subroutine cleanPop(self)
     class(particleDungeon), intent(inout) :: self
@@ -1068,6 +1205,11 @@ contains
     ! Set known (default) state to all particles
     call self % prisoners % kill()
 
+    ! Reset ancestry information
+    if (self % hasIFPData()) then
+      call self % setSizeAncestry(n)
+    end if
+
   end subroutine setSize
 
   !!
@@ -1110,5 +1252,329 @@ contains
     close(id)
 
   end subroutine printToFile
+
+!!
+!! IFP related procedures
+!!
+
+  !!
+  !! Check on whether the dungeon contains IFP data
+  !!
+  pure function hasIFPData(self) result(hasData)
+    class(particleDungeon), intent(in) :: self
+    logical(defBool)                   :: hasData
+
+    hasData = self % sizeIFP > 0
+
+  end function hasIFPData
+
+  !!
+  !! Updates the ancestry information for particles in the dungeon,
+  !! extracting the relevant information from the previous cycle dungeon.
+  !!
+  subroutine updateAncestry(self, prevDungeon)
+    class(particleDungeon), intent(inout) :: self
+    type(particleDungeon), intent(in)     :: prevDungeon
+    integer(shortInt)                     :: i
+    integer(shortInt), save               :: idx, idxNew1, idxNew2, idxOld1, idxOld2
+    !$omp threadprivate(idx, idxNew1, idxNew2, idxOld1, idxOld2)
+
+    ! Skip if not doing IFP
+    if (.not. self % hasIFPData()) return
+
+    ! Copy information from the prevous dungeon based on
+    ! the broodID of the particles currently stored
+    !$omp parallel do
+    do i = 1, self % pop
+      idx = self % prisoners(i) % broodID
+      idxNew1 = (i - 1) * self % sizeIFP + 2
+      idxNew2 = i * self % sizeIFP
+      idxOld1 = (idx - 1) * self % sizeIFP + 1
+      idxOld2 = idx * self % sizeIFP - 1
+      self % ancestorWeights(idxNew1:idxNew2) = &
+              prevDungeon % ancestorWeights(idxOld1:idxOld2)
+      self % ancestorLifetimes(idxNew1:idxNew2) = &
+              prevDungeon % ancestorLifetimes(idxOld1:idxOld2)
+      self % ancestorDelayedGroups(idxNew1:idxNew2) = &
+              prevDungeon % ancestorDelayedGroups(idxOld1:idxOld2)
+
+    end do
+    !$omp end parallel do
+
+  end subroutine updateAncestry
+  
+  !!
+  !! Produces the IFP-weighted average lifetime, beta, and
+  !! groupwise beta values. Requires an input number of
+  !! precursor groups.
+  !!
+  subroutine getIFPValues(self, nPrec, life, beta, betaG)
+    class(particleDungeon), intent(in)           :: self
+    integer(shortInt), intent(in)                :: nPrec
+    real(defReal), intent(out)                   :: life
+    real(defReal), intent(out)                   :: beta
+    real(defReal), dimension(nPrec), intent(out) :: betaG
+    integer(shortInt)                            :: i, j, g, idx1, idx2
+    real(defReal)                                :: lifeTemp, totWeight
+    real(defReal), dimension(nPrec)              :: betaGTemp
+    
+    life = ZERO
+    beta = ZERO
+    betaG = ZERO
+    if (.not. self % hasIFPData()) return
+
+    ! Average over the population
+    do i = 1, self % pop
+      idx1 = (i - 1) * self % sizeIFP + 1
+      idx2 = i * self % sizeIFP
+      totWeight = sum(self % ancestorWeights(idx1:idx2))
+
+      lifeTemp = dot_product(self % ancestorWeights(idx1:idx2),&
+              self % ancestorLifetimes(idx1:idx2))
+      lifeTemp = lifeTemp / totWeight
+      life = life + lifeTemp
+
+      betaGTemp = ZERO
+      do j = idx1, idx2
+        g = self % ancestorDelayedGroups(j)
+
+        if (g > 0) then
+          betaGTemp(g) = betaGTemp(g) + self % ancestorWeights(j)
+        end if
+
+      end do
+
+      betaGTemp = betaGTemp / totWeight
+      betaG = betaG + betaGTemp
+
+    end do
+
+    life = life / self % pop
+    betaG = betaG / self % pop
+    beta = sum(betaG)
+
+  end subroutine getIFPValues
+
+  !!
+  !! Replace IFP data of prisoners from the idxs provided
+  !!
+  subroutine replaceIFP(self, idxArray)
+    class(particleDungeon), intent(inout)        :: self
+    integer(shortInt), dimension(:), intent(in)  :: idxArray
+    real(defReal), dimension(:), allocatable     :: tempWeights
+    real(defReal), dimension(:), allocatable     :: tempLifetimes
+    integer(shortInt), dimension(:), allocatable :: tempGroups
+    integer(shortInt)                            :: i, n 
+    integer(shortInt), save                      :: idx1, idx2, idxOld1, idxOld2
+    character(100),parameter :: Here = 'replaceIFP (particleDungeon_class.f90)'
+    !$omp threadprivate(idx1, idx2, idxOld1, idxOld2)
+
+    ! Protect against out-of-bounds access
+    if (any(idxArray <= 0) .or. any(idxArray > self % pop)) then
+      call fatalError(Here,'Out of bounds access. Population is: '//&
+              numToChar(self % pop)//'. Max idx is: '//numToChar(maxval(idxArray))//&
+              '. Min idx is: '//numToChar(minval(idxArray))//'.')
+    end if
+
+    n = size(idxArray)
+
+    allocate(tempWeights(n * self % sizeIFP))
+    allocate(tempLifetimes(n * self % sizeIFP))
+    allocate(tempGroups(n * self % sizeIFP))
+
+    !$omp parallel do
+    do i = 1, n
+
+      idx1 = (i - 1) * self % sizeIFP + 1
+      idx2 = i * self % sizeIFP
+      idxOld1 = (idxArray(i) - 1) * self % sizeIFP + 1
+      idxOld2 = idxArray(i) * self % sizeIFP
+      tempWeights(idx1:idx2) = self % ancestorWeights(idxOld1:idxOld2)
+      tempLifetimes(idx1:idx2) = self % ancestorLifetimes(idxOld1:idxOld2)
+      tempGroups(idx1:idx2) = self % ancestorDelayedGroups(idxOld1:idxOld2)
+
+    end do
+    !$omp end parallel do
+
+    self % ancestorWeights(1:size(tempWeights)) = tempWeights
+    self % ancestorLifetimes(1:size(tempLifetimes)) = tempLifetimes
+    self % ancestorDelayedGroups(1:size(tempGroups)) = tempGroups
+
+  end subroutine replaceIFP
+
+  !!
+  !! Resize IFP-related information and reset values.
+  !! Should only be called if sizeIFP > 0
+  !!
+  subroutine setSizeAncestry(self, n)
+    class(particleDungeon), intent(inout) :: self
+    integer(shortInt), intent(in)         :: n
+    character(100),parameter :: Here = 'setSizeAncestry (particleDungeon_class.f90)'
+      
+    if (n <= 0) call fatalError(Here, 'Requested population is not +ve: '//numToChar(n))
+    
+    if (allocated(self % ancestorWeights)) then
+      if (size(self % ancestorWeights) < n * self % sizeIFP) then
+        deallocate(self % ancestorWeights)
+        allocate(self % ancestorWeights(n * self % sizeIFP))
+      end if
+    end if
+    if (allocated(self % ancestorLifetimes)) then
+      if (size(self % ancestorLifetimes) < n * self % sizeIFP) then
+        deallocate(self % ancestorLifetimes)
+        allocate(self % ancestorLifetimes(n * self % sizeIFP))
+      end if
+    end if
+    if (allocated(self % ancestorDelayedGroups)) then
+      if (size(self % ancestorDelayedGroups) < n * self % sizeIFP) then
+        deallocate(self % ancestorDelayedGroups)
+        allocate(self % ancestorDelayedGroups(n * self % sizeIFP))
+      end if
+    end if
+    self % ancestorWeights = ZERO
+    self % ancestorLifetimes = ZERO
+    self % ancestorDelayedGroups = 0
+
+  end subroutine setSizeAncestry
+
+  !!
+  !! Perform load balancing on IFP information - send info to another rank
+  !!
+  subroutine loadBalanceIFPSend(self, excess, rank1, rank2, fromBeginning)
+    class(particleDungeon), intent(inout)        :: self
+    integer(shortInt), intent(in)                :: excess
+    integer(shortInt), intent(in)                :: rank1
+    integer(shortInt), intent(in)                :: rank2
+    logical(defBool), intent(in)                 :: fromBeginning
+    integer(shortInt)                            :: idx1, idx2, idx3, idx4, error
+    real(defReal), dimension(:), allocatable     :: ifpRealBuffer
+    integer(shortInt), dimension(:), allocatable :: ifpIntBuffer
+
+#ifdef MPI
+    if (fromBeginning) then
+      idx1 = 1
+      idx2 = self % sizeIFP * excess
+    else
+      idx1 = (self % pop - excess) * self % sizeIFP + 1
+      idx2 = self % pop * self % sizeIFP
+    end if
+
+    ifpRealBuffer = self % ancestorWeights(idx1:idx2)
+    call mpi_send(ifpRealBuffer, excess, MPI_DEFREAL, rank1, rank2, MPI_COMM_WORLD, error)
+    ifpRealBuffer = self % ancestorLifetimes(idx1:idx2)
+    call mpi_send(ifpRealBuffer, excess, MPI_DEFREAL, rank1, rank2, MPI_COMM_WORLD, error)
+    ifpIntBuffer = self % ancestorDelayedGroups(idx1:idx2)
+    call mpi_send(ifpRealBuffer, excess, MPI_SHORTINT, rank1, rank2, MPI_COMM_WORLD, error)
+
+    ! Move remainder of the ancestry down to the beginning
+    if (fromBeginning) then
+      idx3 = excess * self % sizeIFP + 1
+      idx4 = self % pop * self % sizeIFP
+      self % ancestorWeights(idx1:idx2) = self % ancestorWeights(idx3:idx4)
+      self % ancestorLifetimes(idx1:idx2) = self % ancestorLifetimes(idx3:idx4)
+      self % ancestorDelayedGroups(idx1:idx2) = self % ancestorDelayedGroups(idx3:idx4)
+    end if
+#endif
+
+  end subroutine loadBalanceIFPSend
+
+  !!
+  !! Perform load balancing on IFP information - receive info from another rank
+  !!
+  subroutine loadBalanceIFPReceive(self, excess, rank1, rank2, toBeginning)
+    class(particleDungeon), intent(inout)        :: self
+    integer(shortInt), intent(in)                :: excess
+    integer(shortInt), intent(in)                :: rank1
+    integer(shortInt), intent(in)                :: rank2
+    logical(defBool), intent(in)                 :: toBeginning
+    real(defReal), dimension(:), allocatable     :: ifpRealBuffer
+    real(defReal), dimension(:), allocatable     :: recvRealBuffer
+    integer(shortInt), dimension(:), allocatable :: ifpIntBuffer
+    integer(shortInt), dimension(:), allocatable :: recvIntBuffer
+    integer(shortInt)                            :: i, idx1, idx2, error
+
+#ifdef MPI
+    allocate(ifpRealBuffer(excess * self % sizeIFP))
+    allocate(ifpIntBuffer(excess * self % sizeIFP))
+    allocate(recvRealBuffer(excess * self % sizeIFP))
+    allocate(recvIntBuffer(excess * self % sizeIFP))
+        
+    ! First receive weights
+    call mpi_recv(ifpRealBuffer, excess, MPI_DEFREAL, rank1, rank2, &
+                MPI_COMM_WORLD, MPI_STATUS_IGNORE, error)
+    do i = 1, abs(excess)
+      idx1 = (i - 1) * self % sizeIFP + 1
+      idx2 = i * self % sizeIFP
+      recvRealBuffer(idx1:idx2) = ifpRealBuffer(idx1:idx2)
+    end do
+    
+    if (toBeginning) then
+      ! First shift starting ancestry to the end of the dungeon
+      idx1 = self % sizeIFP * excess + 1
+      idx2 = self % sizeIFP * (self % pop + excess)
+      self % ancestorWeights(idx1:idx2) = &
+              self % ancestorWeights(1: self % sizeIFP * self % pop)
+      ! Then prepare to add the new ancestry to the start
+      idx1 = 1
+      idx2 = excess * self % sizeIFP
+    else
+      ! Otherwise add to the end
+      idx1 = self % pop * self % sizeIFP + 1
+      idx2 = (self % pop + excess) * self % sizeIFP
+    end if
+    self % ancestorWeights(idx1:idx2) = recvRealBuffer
+
+    ! Then receive lifetimes
+    call mpi_recv(ifpRealBuffer, excess, MPI_DEFREAL, rank1, rank2, &
+                MPI_COMM_WORLD, MPI_STATUS_IGNORE, error)
+    do i = 1, abs(excess)
+      idx1 = (i - 1) * self % sizeIFP + 1
+      idx2 = i * self % sizeIFP
+      recvRealBuffer(idx1:idx2) = ifpRealBuffer(idx1:idx2)
+    end do
+    
+    if (toBeginning) then
+      ! First shift starting ancestry to the end of the dungeon
+      idx1 = self % sizeIFP * excess + 1
+      idx2 = self % sizeIFP * (self % pop + excess)
+      self % ancestorLifetimes(idx1:idx2) = &
+              self % ancestorLifetimes(1: self % sizeIFP * self % pop)
+      ! Then prepare to add the new ancestry to the start
+      idx1 = 1
+      idx2 = excess * self % sizeIFP
+    else
+      ! Otherwise add to the end
+      idx1 = self % pop * self % sizeIFP + 1
+      idx2 = (self % pop + excess) * self % sizeIFP
+    end if
+    self % ancestorLifetimes(idx1:idx2) = recvRealBuffer
+
+    ! Then receive delayed groups
+    call mpi_recv(ifpIntBuffer, excess, MPI_SHORTINT, rank1, rank2, &
+                MPI_COMM_WORLD, MPI_STATUS_IGNORE, error)
+    do i = 1, abs(excess)
+      idx1 = (i - 1) * self % sizeIFP + 1
+      idx2 = i * self % sizeIFP
+      recvIntBuffer(idx1:idx2) = ifpIntBuffer(idx1:idx2)
+    end do
+    
+    if (toBeginning) then
+      ! First shift starting ancestry to the end of the dungeon
+      idx1 = self % sizeIFP * excess + 1
+      idx2 = self % sizeIFP * (self % pop + excess)
+      self % ancestorDelayedGroups(idx1:idx2) = &
+              self % ancestorDelayedGroups(1: self % sizeIFP * self % pop)
+      ! Then prepare to add the new ancestry to the start
+      idx1 = 1
+      idx2 = excess * self % sizeIFP
+    else
+      ! Otherwise add to the end
+      idx1 = self % pop * self % sizeIFP + 1
+      idx2 = (self % pop + excess) * self % sizeIFP
+    end if
+    self % ancestorDelayedGroups(idx1:idx2) = recvIntBuffer
+#endif  
+
+  end subroutine loadBalanceIFPReceive
 
 end module particleDungeon_class

--- a/ParticleObjects/particleDungeon_class.f90
+++ b/ParticleObjects/particleDungeon_class.f90
@@ -525,7 +525,7 @@ contains
 
     ! Determine the maximum brood ID and sort the dungeon for OMP reproducibility
     maxBroodID = maxval(self % prisoners(1:self % pop) % broodID)
-    call self % sortByBroodID(maxbroodID)
+    call self % sortByBroodID(maxBroodID)
 
     ! Get MPI world size and allocate rng seed vector, needed by all processes
     nRanks = getMPIWorldSize()
@@ -945,6 +945,11 @@ contains
       newPrisoners(i) = self % prisoners(j)    ! Add to new array
       newPrisoners(i) % wgt = wAv              ! Update weight
     end do
+    
+    ! Replace IFP info
+    if (self % hasIFPData()) then
+      call self % replaceIFP(newIdxs)
+    end if
 
     ! Re-size the dungeon to new size
     call self % setSize(N)
@@ -956,11 +961,6 @@ contains
     end do
     !$omp end parallel do
       
-    ! Also replace IFP info
-    if (self % hasIFPData()) then
-      call self % replaceIFP(newIdxs)
-    end if
-
   end subroutine combing
 
   !!
@@ -1028,6 +1028,11 @@ contains
       newPrecursors(i) = self % prisoners(j)       ! Add to new array
       newPrecursors(i) % wgt = uAv / expFactors(j) ! Update weight from timed weight
     end do
+    
+    ! Replace IFP info
+    if (self % hasIFPData()) then
+      call self % replaceIFP(newIdxs)
+    end if
 
     ! Re-size the dungeon to new size
     call self % setSize(N)
@@ -1039,11 +1044,6 @@ contains
     end do
     !$omp end parallel do
     
-    ! Also replace IFP info
-    if (self % hasIFPData()) then
-      call self % replaceIFP(newIdxs)
-    end if
-
   end subroutine precursorCombing
 
   !!
@@ -1204,11 +1204,6 @@ contains
 
     ! Set known (default) state to all particles
     call self % prisoners % kill()
-
-    ! Reset ancestry information
-    if (self % hasIFPData()) then
-      call self % setSizeAncestry(n)
-    end if
 
   end subroutine setSize
 

--- a/ParticleObjects/particle_class.f90
+++ b/ParticleObjects/particle_class.f90
@@ -25,6 +25,18 @@ module particle_class
   public :: printType
 
   !!
+  !! Small object to transmit info relevant to IFP calculations.
+  !! Intend to contain a parent particle's weight, lifetime, and
+  !! precursor group, and to be optionally transmitted to a dungeon 
+  !! when adding a child particle.
+  !!
+  type, public :: infoIFP
+    real(defReal)     :: weight = ZERO
+    real(defReal)     :: lifetime = ZERO
+    integer(shortInt) :: precGroup = 0
+  end type infoIFP
+
+  !!
   !! Particle compressed for storage
   !!
   !! particleStateData contains only the properties (useful for MPI); it is extended into
@@ -46,6 +58,7 @@ module particle_class
   !!   broodID  -> ID of the source particle. It is used to indicate the primogenitor of the particles
   !!               in the particleDungeon so they can be sorted, which is necessary for reproducibility
   !!               with OpenMP
+  !!   precGroup -> precursor group from which the particle was born
   !!
   type, public :: particleStateData
     real(defReal)              :: wgt  = ZERO       ! Particle weight
@@ -62,6 +75,8 @@ module particle_class
     integer(shortInt)          :: uniqueID = -1     ! Unique id at the lowest coord level
     integer(shortInt)          :: collisionN = 0    ! Number of collisions
     integer(shortInt)          :: broodID = 0       ! ID of the source particle
+    integer(shortInt)          :: precGroup = 0     ! Precursor group from which particle was born
+    
   end type particleStateData
 
   !!
@@ -116,7 +131,7 @@ module particle_class
     real(defReal)              :: rho = NO_DENSITY   ! Local density scaling
 
     ! Precursor particle data
-    real(defReal)              :: lambda = INF     ! Precursor decay constant
+    real(defReal)              :: lambda = INF   ! Precursor decay constant
     
     ! Particle flags
     real(defReal)              :: w0             ! Particle initial weight (for implicit, variance reduction...)
@@ -127,6 +142,7 @@ module particle_class
     integer(shortInt)          :: type           ! Particle type
     integer(shortInt)          :: collisionN = 0 ! Index of the number of collisions the particle went through
     integer(shortInt)          :: broodID = 0    ! ID of the brood (source particle number)
+    integer(shortInt)          :: precGroup = 0  ! Precursor group from which particle was born
 
     ! Particle processing information
     class(RNG), pointer        :: pRNG  => null()   ! Pointer to RNG associated with the particle
@@ -157,6 +173,8 @@ module particle_class
     procedure                  :: getUniIdx
     procedure                  :: matIdx
     procedure, non_overridable :: getType
+    procedure                  :: getLifetime
+    procedure                  :: getIFPInfo
 
     ! Enquiry about physical state
     procedure :: getSpeed
@@ -306,6 +324,7 @@ contains
     LHS % collisionN            = RHS % collisionN
     LHS % splitCount            = 0 ! Reinitialise counter for number of splits
     LHS % broodID               = RHS % broodID
+    LHS % precGroup             = RHS % precGroup
 
   end subroutine particle_fromParticleState
 
@@ -435,7 +454,7 @@ contains
   end function matIdx
 
   !!
-  !! Return one of the particle Tpes defined in universal variables
+  !! Return one of the particle types defined in universal variables
   !!
   !! Args:
   !!   None
@@ -457,6 +476,26 @@ contains
     end if
 
   end function getType
+
+  !!
+  !! Return the age of the particle
+  !!
+  !! Args:
+  !!   None
+  !!
+  !! Result:
+  !!   lifetime
+  !!
+  !! Errors:
+  !!   None
+  !!
+  pure function getLifetime(self) result(lifetime)
+    class(particle), intent(in) :: self
+    real(defReal)               :: lifetime
+
+    lifetime = self % time - self % preHistory % time
+
+  end function getLifetime
 
   !!
   !! Return the particle speed in [cm/s]
@@ -517,6 +556,19 @@ contains
     xs = (max(alpha, ZERO) + eta * max(-alpha, ZERO)) / self % getSpeed()
 
   end function getAlphaAbsorption
+
+  !!
+  !! Return info relevant for iterated fission probability
+  !!
+  pure function getIFPInfo(self) result(ifpData)
+    class(particle), intent(in) :: self
+    type(infoIFP)               :: ifpData
+
+    ifpData % weight = self % w
+    ifpData % precGroup = self % precGroup
+    ifpData % lifetime = self % getLifetime()
+
+  end function getIFPInfo
 
   !!
   !! Produce a delayed neutron from a precursor.
@@ -830,6 +882,7 @@ contains
     LHS % cellIdx  = RHS % coords % cell()
     LHS % collisionN = RHS % collisionN
     LHS % broodID    = RHS % broodID
+    LHS % precGroup  = RHS % precGroup
 
   end subroutine particleState_fromParticle
 
@@ -848,6 +901,7 @@ contains
     LHS % isMG = RHS % isMG
     LHS % type = RHS % type
     LHS % time = RHS % time
+    LHS % lambda = RHS % lambda
 
     ! Save all indexes
     LHS % matIdx   = RHS % matIdx
@@ -855,12 +909,13 @@ contains
     LHS % cellIdx  = RHS % cellIdx
     LHS % collisionN = RHS % collisionN
     LHS % broodID    = RHS % broodID
+    LHS % precGroup  = RHS % precGroup
 
   end subroutine particleState_fromParticleStateData
 
   !!
   !! Define equal operation on phase coordinates
-  !!  Phase coords are equal if all their components are the same
+  !! Phase coords are equal if all their components are the same
   !!
   function equal_particleState(LHS,RHS) result(isEqual)
     class(particleState), intent(in) :: LHS
@@ -879,12 +934,14 @@ contains
     isEqual = isEqual .and. LHS % uniqueID == RHS % uniqueID
     isEqual = isEqual .and. LHS % collisionN == RHS % collisionN
     isEqual = isEqual .and. LHS % broodID    == RHS % broodID
+    isEqual = isEqual .and. LHS % precGroup  == RHS % precGroup
 
-    if( LHS % isMG ) then
+    if(LHS % isMG) then
       isEqual = isEqual .and. LHS % G == RHS % G
     else
       isEqual = isEqual .and. LHS % E == RHS % E
     end if
+
   end function equal_particleState
 
   !!
@@ -900,6 +957,9 @@ contains
     print*, 'isMG: ', self % isMG
     print*, 'Weight: ', self % wgt
     print*, 'Time: ', self % time
+    print*, 'Precursor group: ', self % precGroup
+    print*, 'Precursor decay constant: ', self % lambda
+    print*, 'Brood ID: ', self % broodID
 
   end subroutine display_particleState
 
@@ -922,9 +982,10 @@ contains
     self % uniqueID = -1
     self % collisionN = 0
     self % broodID    = 0
+    self % precGroup  = 0
+    self % lambda = INF
 
   end subroutine kill_particleState
-
 
 !!<><><><><><><>><><><><><><><><><><><>><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 !! Misc Procedures

--- a/PhysicsPackages/alphaPhysicsPackage_class.f90
+++ b/PhysicsPackages/alphaPhysicsPackage_class.f90
@@ -104,6 +104,7 @@ module alphaPhysicsPackage_class
     real(defReal)      :: eta
     integer(shortInt)  :: bufferSize
     logical(defBool)   :: UFS = .false.
+    integer(shortInt)  :: sizeIFP = 0
 
     ! Calculation components
     type(particleDungeon), pointer :: thisCycle    => null()
@@ -250,6 +251,7 @@ contains
       end do gen
       !$omp end parallel do
 
+      call self % nextCycle % updateAncestry(self % thisCycle)
       call self % thisCycle % cleanPop()
 
       ! Update RNG
@@ -345,8 +347,8 @@ contains
     ! Allocate and initialise particle Dungeons
     allocate(self % thisCycle)
     allocate(self % nextCycle)
-    call self % thisCycle % init(2 * self % pop)
-    call self % nextCycle % init(2 * self % pop)
+    call self % thisCycle % init(2 * self % pop, self % sizeIFP)
+    call self % nextCycle % init(2 * self % pop, self % sizeIFP)
 
     ! Generate initial source
     print *, "GENERATING INITIAL SOURCE"
@@ -432,6 +434,9 @@ contains
     call dict % get( self % N_active,'active')
     call dict % get( nucData, 'XSdata')
     call dict % get( energy, 'dataType')
+    
+    ! Read iterated fission probability generation size
+    call dict % getOrDefault(self % sizeIFP, 'sizeIFP', 0)
 
     ! Parallel buffer size
     call dict % getOrDefault( self % bufferSize, 'buffer', 1000)

--- a/PhysicsPackages/eigenPhysicsPackage_class.f90
+++ b/PhysicsPackages/eigenPhysicsPackage_class.f90
@@ -107,6 +107,7 @@ module eigenPhysicsPackage_class
     integer(shortInt)  :: bufferSize
     logical(defBool)   :: UFS = .false.
     logical(defBool)   :: reproducible = .true.
+    integer(shortInt)  :: sizeIFP = 0
 
     ! Calculation components
     type(particleDungeon), pointer :: thisCycle    => null()
@@ -251,6 +252,7 @@ contains
       end do gen
       !$omp end parallel do
 
+      call self % nextCycle % updateAncestry(self % thisCycle)
       call self % thisCycle % cleanPop()
 
       ! Update RNG
@@ -352,8 +354,8 @@ contains
     ! Allocate and initialise particle Dungeons
     allocate(self % thisCycle)
     allocate(self % nextCycle)
-    call self % thisCycle % init(2 * self % pop)
-    call self % nextCycle % init(2 * self % pop)
+    call self % thisCycle % init(2 * self % pop, self % sizeIFP)
+    call self % nextCycle % init(2 * self % pop, self % sizeIFP)
 
     ! Generate initial source
     call statusMsg("GENERATING INITIAL FISSION SOURCE")
@@ -442,6 +444,9 @@ contains
     call dict % get( self % N_active,'active')
     call dict % get( nucData, 'XSdata')
     call dict % get( energy, 'dataType')
+
+    ! Read iterated fission probability generation size
+    call dict % getOrDefault(self % sizeIFP, 'sizeIFP', 0)
 
     ! Check if the calculation has to be reproducible with MPI
     call dict % getOrDefault(self % reproducible, 'reproducible', .true.)

--- a/Tallies/TallyClerks/CMakeLists.txt
+++ b/Tallies/TallyClerks/CMakeLists.txt
@@ -15,6 +15,7 @@ add_sources(./tallyClerk_inter.f90
             ./eventClerk_class.f90
             ./centreOfMassClerk_class.f90
             ./mgXsClerk_class.f90
+	    ./kineticIFPClerk_class.f90
              )
 
 add_unit_tests(./Tests/collisionClerk_test.f90

--- a/Tallies/TallyClerks/kAlphaAnalogClerk_class.f90
+++ b/Tallies/TallyClerks/kAlphaAnalogClerk_class.f90
@@ -212,8 +212,8 @@ contains
     ! Print estimates to a console
     print '(A,F8.5,A,F8.5)', 'k (analog): ',  k, ' +/- ', STDk
     print '(A,F8.5)', 'k current: ',  self % k
-    print '(A,F8.4,A,F8.4)', 'Alpha accumulated: ',  alpha/10**6, 'us^-1 +/- ', STDa/10**6
-    print '(A,F8.4,A)', 'Alpha current: ',  self % alpha/10**6, 'us^-1'
+    print '(A,ES12.5,A,ES12.5)', 'Alpha accumulated: ',  alpha/10**6, 'us^-1 +/- ', STDa/10**6
+    print '(A,ES12.5,A)', 'Alpha current: ',  self % alpha/10**6, 'us^-1'
 
   end subroutine display
 

--- a/Tallies/TallyClerks/kineticIFPClerk_class.f90
+++ b/Tallies/TallyClerks/kineticIFPClerk_class.f90
@@ -1,0 +1,212 @@
+module kineticIFPClerk_class
+
+  use numPrecision
+  use tallyCodes
+  use universalVariables,    only : MAX_COL
+  use dictionary_class,      only : dictionary
+  use genericProcedures,     only : fatalError, numToChar
+  use display_func,          only : statusMsg
+  use particle_class,        only : particle
+  use particleDungeon_class, only : particleDungeon
+  use outputFile_class,      only : outputFile
+
+  use scoreMemory_class,     only : scoreMemory
+  use tallyClerk_inter,      only : tallyClerk, kill_super => kill
+
+  implicit none
+  private
+
+  integer(shortInt), parameter :: N_PREC = 8       ! Fixed number of precursor groups. Some data
+                                                   ! libraries will have only 6 groups and so
+                                                   ! will have tallies of 0 in groups 7 and 8.
+  integer(shortInt), parameter :: MEM_SIZE = N_PREC + 2 ! Total memory size
+  
+  ! Locations of different bins wrt memory address of the clerk
+  integer(longInt), parameter  :: REMOV_TIME = 0 ,&  ! Address of removal time
+                                  BETA_EFF = 1       ! Address of beta effective
+
+  !!
+  !! Iterated fission probability-based tally for kinetic parameters.
+  !! These are beta-effective and the effective removal time.
+  !! Meaningful results require that the calculation is run with a non-zero
+  !! IFP generation size. Otherwise outputs will be zero.
+  !! Note that removal time can be converted to generation time by division
+  !! by keff.
+  !!
+  !! Private Members:
+  !!
+  !! SAMPLE DICTIOANRY INPUT:
+  !!
+  !! myClerk {
+  !!   type kineticIFPClerk;
+  !! }
+  !!
+  type, public,extends(tallyClerk) :: kineticIFPClerk
+  contains
+    ! Procedures used during build
+    procedure :: init
+    procedure :: kill
+    procedure :: validReports
+    procedure :: getSize
+
+    ! File reports and check status -> run-time procedures
+    procedure :: reportCycleEnd
+
+    ! Output procedures
+    procedure  :: display
+    procedure  :: print
+
+  end type kineticIFPClerk
+
+
+contains
+
+  !!
+  !! Initialise from dictionary and name
+  !!
+  !! See tallyClerk_inter for details
+  !!
+  subroutine init(self, dict, name)
+    class(kineticIFPClerk), intent(inout) :: self
+    class(dictionary), intent(in)         :: dict
+    character(nameLen), intent(in)        :: name
+    character(100),parameter :: Here = 'init (kineticIFPClerk.f90)'
+
+    ! Needs no settings, just load name
+    call self % setName(name)
+
+  end subroutine init
+
+  !!
+  !! Return to uninitialised state
+  !!
+  elemental subroutine kill(self)
+    class(kineticIFPClerk), intent(inout) :: self
+
+    ! Superclass
+    call kill_super(self)
+
+  end subroutine kill
+
+  !!
+  !! Returns array of codes that represent diffrent reports
+  !!
+  !! See tallyClerk_inter for details
+  !!
+  function validReports(self) result(validCodes)
+    class(kineticIFPClerk),intent(in)          :: self
+    integer(shortInt),dimension(:),allocatable :: validCodes
+
+    validCodes = [cycleEnd_CODE]
+
+  end function validReports
+
+  !!
+  !! Return memory size of the clerk
+  !!
+  !! See tallyClerk_inter for details
+  !!
+  elemental function getSize(self) result(S)
+    class(kineticIFPClerk), intent(in) :: self
+    integer(shortInt)                  :: S
+
+    S = MEM_SIZE
+
+  end function getSize
+
+  !!
+  !! Process end of the cycle
+  !!
+  !! See tallyClerk_inter for details
+  !!
+  subroutine reportCycleEnd(self, end, mem)
+    class(kineticIFPClerk), intent(inout) :: self
+    class(particleDungeon), intent(in)    :: end
+    type(scoreMemory), intent(inout)      :: mem
+    real(defReal)                         :: tau, beta
+    real(defReal), dimension(N_PREC)      :: betaG
+    integer(shortInt)                     :: g
+
+    ! For each particle in the dungeon, obtain its ancestry.
+    ! The IFP-weighted estimator for removal time is:
+    ! For each particle:
+    !   sum over ancestors(weight * lifetime) / sum over ancestors(weight)
+    !
+    ! The IFP-weighted estimator for beta-efffective is:
+    ! For each particle:
+    !   sum over ancestors(weight * delta_(born from prec)) / sum over ancestors(weight)
+    ! 
+    ! The beta estimator can be decomposed into groups by setting the delta = 1
+    ! only if the neutron is born from a particular delayed group
+    !
+    ! These quantities are computed in the dungeon, averaged over particles, 
+    ! to prevent copying many arrays into the tally.
+
+    call end % getIFPValues(N_PREC, tau, beta, betaG)
+    call mem % accumulate(tau, self % getMemAddress() + REMOV_TIME)
+    call mem % accumulate(beta, self % getMemAddress() + BETA_EFF)
+    do g = 1, N_PREC
+      call mem % accumulate(betaG(g), self % getMemAddress() + BETA_EFF + g)
+    end do
+
+  end subroutine reportCycleEnd
+
+  !!
+  !! Display convergance progress on the console
+  !!
+  !! See tallyClerk_inter for details
+  !!
+  subroutine display(self, mem)
+    class(kineticIFPClerk), intent(in)  :: self
+    type(scoreMemory), intent(in)       :: mem
+    real(defReal)                       :: tau, STDtau, beta, STDbeta
+    character(MAX_COL)                  :: buffer
+
+    call mem % getResult(tau, STDtau, self % getMemAddress() + REMOV_TIME)
+    call mem % getResult(beta, STDbeta, self % getMemAddress() + BETA_EFF)
+
+    ! Print estimates to a console
+    write(buffer, '(A,ES12.5,A,ES12.5)') 'Removal time (IFP): ', tau, ' +/- ', STDtau
+    call statusMsg(buffer)
+    write(buffer, '(A,ES12.5,A,ES12.5)') 'Beta-effective (IFP): ', beta, ' +/- ', STDbeta
+    call statusMsg(buffer)
+
+  end subroutine display
+
+  !!
+  !! Write contents of the clerk in the slot to output file
+  !!
+  !! See tallyClerk_inter for details
+  !!
+  subroutine print(self, outFile, mem)
+    class(kineticIFPClerk), intent(in) :: self
+    class(outputFile), intent(inout)   :: outFile
+    type(scoreMemory), intent(in)      :: mem
+    real(defReal)                      :: tau, beta, STDtau, STDbeta
+    real(defReal), dimension(N_PREC)   :: betaG, STDbetaG
+    integer(shortInt)                  :: g
+    character(nameLen)                 :: name
+
+    ! Get result values
+    call mem % getResult(tau, STDtau, self % getMemAddress() + REMOV_TIME)
+    call mem % getResult(beta, STDbeta, self % getMemAddress() + BETA_EFF)
+
+    do g = 1, N_PREC
+      call mem % getResult(betaG(g), STDbetaG(g), self % getMemAddress() + BETA_EFF + g)
+    end do
+
+    ! Print to output file
+    call outFile % startBlock(self % getName())
+    name = 'Removal_time'
+    call outFile % printResult(tau, STDtau, name)
+    name = 'Beta_effective'
+    call outFile % printResult(beta, STDbeta, name)
+    do g = 1, N_PREC
+      name = 'Beta_g'//numToChar(g)
+      call outFile % printResult(betaG(g), STDbetaG(g), name)
+    end do
+    call outFile % endBlock()
+
+  end subroutine print
+
+end module kineticIFPClerk_class

--- a/Tallies/TallyClerks/tallyClerkFactory_func.f90
+++ b/Tallies/TallyClerks/tallyClerkFactory_func.f90
@@ -20,6 +20,7 @@ module tallyClerkFactory_func
   use eventClerk_class,                only : eventClerk
   use kAlphaAnalogClerk_class,         only : kAlphaAnalogClerk
   use removalTimeClerk_class,          only : removalTimeClerk
+  use kineticIFPClerk_class,           only : kineticIFPClerk
   use mgXsClerk_class,                 only : mgXsClerk
 
   implicit none
@@ -43,6 +44,7 @@ module tallyClerkFactory_func
                                                                         'dancoffBellClerk         ',&
                                                                         'kAlphaAnalogClerk        ',&
                                                                         'removalTimeClerk         ',&
+                                                                        'kineticIFPClerk          ',&
                                                                         'mgXsClerk                ']
 
 contains
@@ -104,6 +106,9 @@ contains
 
      case('mgXsClerk')
        allocate(mgXsClerk :: new)
+
+     case('kineticIFPClerk')
+       allocate(kineticIFPClerk :: new)
 
       case default
         print *, AVALIBLE_tallyClerks

--- a/docs/Input Manual.rst
+++ b/docs/Input Manual.rst
@@ -37,6 +37,10 @@ eigenPhysicsPackage, used for criticality (or eigenvalue) calculations
   requests to print the particle source (location, direction, energy, broodID and weight
   of each particle in the particleDungeon) to a text/bin file. If running with MPI, 
   this is done by each MPI rank separately
+* sizeIFP (*optional*, default = 0): number of generations of neutrons to recall when
+  scoring importance-weighted tallies. Stores/transfers more information in the dungeon.
+  Should be off by default due to additional overheads, but typically set to 10 when
+  attempting to estimate kinetic parameters.
 
 Example: ::
 
@@ -49,6 +53,7 @@ Example: ::
         seed     -244654;
         outputFile PWR_1;
         outputFormat asciiJSON;
+        sizeIFP 20;
 
         transportOperator { <Transport operator definition> }
         collisionOperator { <Collision operator definition> }
@@ -222,6 +227,10 @@ alphaPhysicsPackage, used to estimate the alpha eigenvalue by the k-alpha algori
   to print the particle source (location, direction, energy of each particle
   in the particleDungeon) to a text file. If running with MPI, this is done 
   by each MPI rank separately
+* sizeIFP (*optional*, default = 0): number of generations of neutrons to recall when
+  scoring importance-weighted tallies. Stores/transfers more information in the dungeon.
+  Should be off by default due to additional overheads, but typically set to 10 when
+  attempting to estimate kinetic parameters.
 
 Example: ::
 
@@ -236,6 +245,7 @@ Example: ::
         alpha_0 100000;
         outputFile PuSphere;
         outputFormat asciiJSON;
+        sizeIFP 10;
 
         transportOperator { <Transport operator definition> }
         collisionOperator { <Collision operator definition> }
@@ -1561,6 +1571,17 @@ Example: ::
 
       tally {
         tau { type removalTimeClerk; }
+      }
+
+* kineticIFPClerk, estimates the importance-weighted lifetime and beta-effective
+  of neutrons. Must be used in conjunction with either the k or alpha physics packages
+  with the option ``sizeIFP`` greater than 0. Also provides values of beta for each
+  precursor group. Can be displayed to the terminal.
+
+Example: ::
+
+      tally {
+        ifp { type kineticIFPClerk; }
       }
 
 Tally Responses


### PR DESCRIPTION
This PR adds the ability to estimate importance-weighted kinetics parameters (beta-eff, effective lifetime) using the iterated fission probability method.

The theoretical approach is very similar to that described in the 2014 paper by Leppanen et al: https://www.sciencedirect.com/science/article/pii/S0306454913005628
This entails storing several generations of lifetimes and delayed neutron precursor groups.

The tricky bit is how to do this storage and data management. I opted to put most of the work in the dungeon, rather than making the particle or particle state much heavier. Particles now store their precursor group and can compute their lifetimes up to their current point in time. On producing a new particle, the parent's weight, precursor group, and lifetime are also sent to the dungeon.

In the physics packages (currently only k and alpha) one must initialise the dungeon with 'sizeIFP', which is 0 by default. This describes how many generations of information are stored. This can be set to any value >=0. The trade-off is more overhead for larger values, but more accurate IFP estimates. On producing a new particle, nextCycle receives the parent's info. At the end of a cycle, there is a new procedure (updateAncestry) which transfers the previous generations of information from thisCycle to nextCycle, using the broodID of the particle in nextCycle which it shares with its parent to begin. The hardest part is that this involves keeping track of this ancestry as the particles are sorted and population controlled. This bit of the code could probably be more elegant, but as it exists it is quite separate from current population control code.

There is also a new tally for the important parameters. It is quite simple because most of the work of computing relevant values is done inside the particleDungeon. This is because it is quite a lot more computationally efficient than copying info to the tally and avoids cache misses.

Along the way I spotted some small errors. There was one occasional out of bounds access in the heap (probably compiler dependent) which was fixed. Also some of the logic for alpha calculations in the collision processor was fixed, preventing erroneous negative weights.

Currently, for a handful of benchmarks I have run, the kinetic parameters agree well with the above paper without much obvious slowdown. However, I want to do a bit more testing, especially with alpha where kinetic parameters are generally less established. I also mean to add unit tests shortly.

It is conceivable that this approach might not generalise if we want to later do, e.g., collision histories (Serpent has more complicated event structures for that, which is a superset of their IFP approach) but until then I think this provides the capability without much complexity.

All being well this should open up a much bigger scope for validation and be complementary to other time-dependent capabilities.