### PR TITLE
aceNeutronDatabase init reads 'maxNuc' before it is assigned

### DIFF
--- a/NuclearData/ceNeutronData/aceDatabase/Tests/aceNeutronDatabase_iTest.f90
+++ b/NuclearData/ceNeutronData/aceDatabase/Tests/aceNeutronDatabase_iTest.f90
@@ -23,7 +23,7 @@ module aceNeutronDatabase_iTest
   implicit none
 
   ! Material definitions
-  character(*),parameter :: MAT_INPUT_STR = &
+  character(*), parameter :: MAT_INPUT_STR = &
   & "water {                     &
   &       composition {          &
   &       1001.03 5.028E-02;     &
@@ -34,6 +34,24 @@ module aceNeutronDatabase_iTest
   &        composition {         &
   &        92233.03 2.286E-02;   &
   &        8016.03  4.572E-02;   &
+  &                    }         &
+  &       }"
+
+  ! Materials with DIFFERENT nuclide counts (1 and 4), the larger one second, so
+  ! that the maximum nuclide count in aceNeutronDatabase % init must grow across
+  ! the material loop before the nuclide-index workspace is allocated.
+  character(*), parameter :: MAT_MIXED_STR = &
+  & "oxygen {                    &
+  &         composition {        &
+  &         8016.03 2.505E-02;   &
+  &                     }        &
+  &         }                    &
+  &  fuel {                      &
+  &        composition {         &
+  &        1001.03  5.028E-02;   &
+  &        8016.03  2.505E-02;   &
+  &        92233.03 2.286E-02;   &
+  &        92235.03 1.000E-03;   &
   &                    }         &
   &       }"
 
@@ -266,5 +284,93 @@ contains
     call mm_kill()
 
   end subroutine test_aceNeutronDatabase
+
+  !!
+  !! Material -> nuclide mapping built by init, for materials of different sizes
+  !!
+  !! The mapping is assembled through the nuclide-index workspace sized by the
+  !! maximum nuclide count over all materials, so these assertions pin exactly
+  !! the state that workspace produces: nuclide list sizes, nuclide association,
+  !! ZAID identity, and the fissile flags accumulated in the same loop.
+  !!
+@Test
+  subroutine test_initMaterialNuclideMapping()
+    character(nameLen)               :: ZAID
+    class(nuclearDatabase), pointer  :: ptr
+    integer(shortInt)                :: i, nH1, nO16, nU233, nU235
+    type(aceNeutronDatabase), target :: data
+    type(ceNeutronMaterial), pointer :: mat
+    type(aceNeutronNuclide), pointer :: nuc
+    type(dictionary)                 :: dataDict, matDict
+
+    ! Prepare dictionaries and build material menu.
+    call charToDict(matDict, MAT_MIXED_STR)
+    call charToDict(dataDict, ACE_INPUT_STR)
+    call mm_init(matDict)
+
+    ! Initialise data.
+    ptr => data
+    call data % init(dataDict, ptr, silent = .true.)
+    call data % activate([1, 2], silent = .true.)
+
+    ! Material 1 (oxygen): single nuclide, non-fissile.
+    mat => ceNeutronMaterial_TptrCast(data % getMaterial(1))
+    @assertAssociated(mat)
+    @assertEqual(1, size(mat % nuclides))
+    @assertEqual(1, size(mat % dens))
+    @assertFalse(mat % isFissile())
+
+    nuc => aceNeutronNuclide_TptrCast(data % getNuclide(mat % nuclides(1)))
+    @assertAssociated(nuc)
+    @assertEqual('8016.03c', trim(adjustl(nuc % ZAID)))
+
+    ! Material 2 (fuel): four nuclides, fissile.
+    mat => ceNeutronMaterial_TptrCast(data % getMaterial(2))
+    @assertAssociated(mat)
+    @assertEqual(4, size(mat % nuclides))
+    @assertEqual(4, size(mat % dens))
+    @assertTrue(mat % isFissile())
+
+    ! Every stored index must map to an associated nuclide, and the four
+    ! ZAIDs of the composition must each appear exactly once.
+    nH1 = 0
+    nO16 = 0
+    nU233 = 0
+    nU235 = 0
+    do i = 1, size(mat % nuclides)
+      nuc => aceNeutronNuclide_TptrCast(data % getNuclide(mat % nuclides(i)))
+      @assertAssociated(nuc)
+
+      ZAID = trim(adjustl(nuc % ZAID))
+      select case(trim(ZAID))
+        case('1001.03c')
+          nH1 = nH1 + 1
+
+        case('8016.03c')
+          nO16 = nO16 + 1
+
+        case('92233.03c')
+          nU233 = nU233 + 1
+
+        case('92235.03c')
+          nU235 = nU235 + 1
+
+      end select
+
+    end do
+    @assertEqual(1, nH1, 'H-1 mapped wrong number of times.')
+    @assertEqual(1, nO16, 'O-16 mapped wrong number of times.')
+    @assertEqual(1, nU233, 'U-233 mapped wrong number of times.')
+    @assertEqual(1, nU235, 'U-235 mapped wrong number of times.')
+
+    ! Assert that four unique nuclides were loaded in total.
+    @assertAssociated(ceNeutronNuclide_CptrCast(data % getNuclide(4)))
+    @assertNotAssociated(ceNeutronNuclide_CptrCast(data % getNuclide(5)))
+
+    ! Clean everything.
+    call data % kill()
+    call mm_kill()
+
+  end subroutine test_initMaterialNuclideMapping
 
 end module aceNeutronDatabase_iTest

--- a/NuclearData/ceNeutronData/aceDatabase/aceNeutronDatabase_class.f90
+++ b/NuclearData/ceNeutronData/aceDatabase/aceNeutronDatabase_class.f90
@@ -914,6 +914,7 @@ contains
 
     ! Create list of all nuclides. Loop over materials
     ! Find maximum number of nuclides: maxNuc
+    maxNuc = 0
     do i = 1, mm_nMat()
       mat => mm_getMatPtr(i)
       maxNuc = max(maxNuc, size(mat % nuclides))


### PR DESCRIPTION
## Mechanism

In `NuclearData/ceNeutronData/aceDatabase/aceNeutronDatabase_class.f90`, `init` declares (:887):

```fortran
    integer(shortInt)                                :: maxNuc
```

with no initialiser, and the variable's **first** access is a read, inside the material loop (:917-919):

```fortran
    do i = 1, mm_nMat()
      mat => mm_getMatPtr(i)
      maxNuc = max(maxNuc, size(mat % nuclides))
```

A reference to an undefined variable is nonconforming Fortran (2008 and later), and this one sits on the unconditional build path of every continuous-energy run. The accumulated value then sizes the per-material nuclide-index workspace (:1056):

```fortran
    allocate(nucIdxs(maxNuc))
```

## Practical behaviour

Because the variable only feeds a `max()` accumulator, its final value is `max(<initial stack content>, true maximum)`, so `nucIdxs` can never end up *undersized*. The observable failure modes are therefore:

- **Initial stack content zero** (first-touch pages), **negative, or positive but below the true maximum**: the accumulation is correct by accident, which is why it has gone unnoticed.
- **Positive stack content above the true maximum** (stack-frame reuse, different compiler / flags): `nucIdxs` is allocated oversized; silent memory waste, or an allocation failure at init if the garbage is large.
- **Debug builds that initialise integers to a large positive value** (e.g. `-finit-integer=2000000000`): a ~2·10⁹-element allocation attempt; an abort at init, or a silent multi-gigabyte oversize on hosts with enough memory to satisfy the request.

Note that this is not merely theoretical: during test development on the unpatched tree, extending the integration-test source file was enough to perturb the stack contents. `init` then aborted with `Error allocating 6118143800 bytes` (i.e., ~6 GB) at the `allocate(nucIdxs(maxNuc))` line, killing an unrelated pre-existing test before the new one ran.

The failed-allocation leg also fires while running the stock integration suite repeatedly: the URR probability-tables integration test aborted in roughly half of invocations with `Error allocating N bytes: Cannot allocate memory` at the `allocate(nucIdxs(maxNuc))` line, with N varying per invocation. Ten distinct values between 4.9 GB and 8.5 GB were observed (e.g. 7,093,720,776 and 5,153,453,880 bytes). The remaining invocations completed normally.

## Provenance

Present since `d1c49cb6` ("Implemented build procedure for aceNeutronDatabase", 2019-08-13). The variable was introduced already unseeded.

## Fix

One line before the loop:

```fortran
    ! Create list of all nuclides. Loop over materials
    ! Find maximum number of nuclides: maxNuc
    maxNuc = 0
    do i = 1, mm_nMat()
```

## Test plan

A second test, `test_initMaterialNuclideMapping`, is added to the existing integration test module `NuclearData/ceNeutronData/aceDatabase/Tests/aceNeutronDatabase_iTest.f90`, with its own material definition (`MAT_MIXED_STR`): the module's existing fixture has two materials of two nuclides each, whereas this defect needs materials of *different* nuclide counts, so that the maximum has to grow across the material loop. The two materials hold 1 and 4 nuclides, drawn from the existing `testLib` fixture, with the larger one second.

The test asserts the init-built material → nuclide mapping: per-material nuclide-list and density-array sizes, nuclide association for every stored index, ZAID identity of each mapped nuclide (each of the four exactly once), the fissile flags accumulated through the same loop, and the total number of distinct nuclides loaded.

**Note:** this test does not fail on current `main`, and it cannot. The size of the allocation depends on whatever the stack happens to hold, and in practice that is usually zero, so the mapping comes out correct. The test's purpose is to pin the behaviour the fix guarantees, so that the mapping is checked from now on.

To see the defect itself, either run the integration suite several times (the URR test aborts in roughly half the runs, as described above), or build with `-finit-integer=2000000000`, which fills uninitialised integers with a large positive value and makes the allocation fail every time.