### PR TITLE
dictionary: initialise the new keyword slots when growing the store

### DIFF
--- a/DataStructures/Tests/dictionary_test.f90
+++ b/DataStructures/Tests/dictionary_test.f90
@@ -609,4 +609,35 @@ contains
 
   end subroutine testAddressOfNodes
 
+  !!
+  !! Test lookups on a dictionary whose keyword array has been extended.
+  !!
+@Test
+  subroutine testExtendByLookups(this)
+    class(test_dictionary), intent(inout) :: this
+    character(nameLen)                    :: name
+    integer(shortInt)                     :: i, storedInt
+
+    ! setUp already forces one extension (init(1) + 8 entries). Force a
+    ! second one by storing additional keywords.
+    do i = 1, 20
+      write(name, '(A,I0)') 'extendedKeyword', i
+      call this % dict % store(name, i)
+
+    end do
+
+    ! All new entries stored must be retrievable.
+    do i = 1, 20
+      write(name, '(A,I0)') 'extendedKeyword', i
+      call this % dict % get(storedInt, name)
+      @assertEqual(i, storedInt, 'Value stored across extension.')
+
+    end do
+
+    ! Lookups of absent keywords must scan the extended tail cleanly.
+    @assertFalse(this % dict % isPresent('absentKeyword'), 'isPresent on absent keyword.')
+    @assertTrue(this % dict % isPresent('myReal'), 'isPresent on keyword stored before extension.')
+
+  end subroutine testExtendByLookups
+
 end module dictionary_test

--- a/DataStructures/dictionary_class.f90
+++ b/DataStructures/dictionary_class.f90
@@ -282,6 +282,7 @@ contains
     allocate(entries(newSize) )
 
     keywords(1:oldSize) = self % keywords
+    keywords(oldSize + 1:newSize) = ''
 
     do i=1,oldSize
      entries(i) = self % entries(i)


### PR DESCRIPTION
## Mechanism

`dictionary % init` blanks the freshly allocated `keywords` array but `extendBy` does not: it allocates the larger array and copies only `keywords(1:oldSize)`, leaving slots `oldSize + 1:newSize` uninitialised (:281-284).

Three lookup procedures scan the *full* `keywords` array with `linFind`:

* `isPresent` (:432)
* `getSize` (keyword variant, :448)
* `search` (:1513)

Such that every lookup performed after an extension reads uninitialised memory, with the exception of the duplicate check in `getEmptyIdx` (:253), which is bounded to keywords(1:dictLen).

## Impact

1. **Undefined-behaviour reads on essentially every run.** `fileToDict` starts dictionaries at `init(5)` with stride 20, so any input file with more than five entries at one level extends its dictionary. Even the shipped `dictionary_test` fixture (`init(1)` plus eight stores) extends, which means the existing unit tests already scan a garbage tail today.
2. **A small probability of a spurious keyword match.** If a garbage slot happens to compare equal to a queried keyword, `search` returns a slot whose `dictContent` was never filled: the caller then gets a type-mismatch `fatalError` or a wrong entry.

## Provenance

Present since `f65f36b5` (2018-02-03), "Dictionary was implemented".

## Reproduction

Measured on the current `main` unit tests (gfortran 13, `-O0 -g`, aarch64 Linux):

```
valgrind --track-origins=yes --error-limit=no ./Build/unitTests -f 'dictionary'
```

reports **741 errors from 46 contexts**, every one of them an uninitialised-value read inside `linFind` with the same origin:

```
==284887== Conditional jump or move depends on uninitialised value(s)
==284887==    at 0x2E6FC8: __genericprocedures_MOD_linfind_char (genericProcedures.f90:536)
==284887==    by 0x3A02BB: __dictionary_class_MOD_ispresent (dictionary_class.f90:433)
==284887==    by 0x2AC167: __dictionary_test_MOD_testispresent (dictionary_test.f90:522)
==284887==  Uninitialised value was created by a heap allocation
==284887==    at 0x4885250: malloc
==284887==    by 0x3A16C3: __dictionary_class_MOD_extendby (dictionary_class.f90:281)
==284887==    by 0x3A2B0F: __dictionary_class_MOD_getemptyidx (dictionary_class.f90:243)
==284887==    by 0x395B93: __dictionary_class_MOD_store_int (dictionary_class.f90:1382)
==284887==    by 0x2B2DAF: __dictionary_test_MOD_setup (dictionary_test.F90:39)
```

The reports come from the *existing* tests, not only the one added here. `testIsPresent`, `testPointerPassing`, `testGettingInt`, `testGettingBool`, `testGettingRealArray`, `testGettingIntArray`, `testGettingNameLenChar`, `testGettingPathLenChar` and their siblings all trip it. The origin chain shows the trigger: the fixture's `setUp` stores its eighth entry, which extends the dictionary from `init(1)`, and every later lookup then scans the uninitialised tail.

With the one-line fix below applied, the same command reports **0 errors from 0 contexts**.

A deterministic reproduction of the spurious-match consequence is not feasible, since it depends on the content of the uninitialised memory; the undefined read itself is deterministic and is what the numbers above show.

## Fix

One line after setting the front of the extended `keywords` array:

```
keywords(oldSize + 1:newSize) = ''
```

## Test plan

A new test, `testExtendedLookups`, added in `dictionary_test`. It forces a second extension using 20 generated keywords, checks every entry is retrievable across the extension, and checks absent-keyword lookups that scan the extended tail. Note that this test passes both with and without the fix: the tail scan reads uninitialised memory rather than failing an assertion, so the test pins the contract and gives valgrind a clean place to point at, while the evidence of the defect is the report above.