### PR TITLE
dictParser rejects input files that lack a trailing newline

### DIFF
--- a/DataStructures/Tests/dictParser_iTest.f90
+++ b/DataStructures/Tests/dictParser_iTest.f90
@@ -45,5 +45,30 @@ contains
 
   end subroutine testFromFile
 
+  !!
+  !! Test reading a dictionary from a file without a trailing newline.
+  !!
+@Test
+  subroutine testFromFileNoTrailingNewline()
+    class(dictionary), pointer :: dictPtr
+    integer(shortInt)          :: tempInt
+    real(defReal)              :: tempReal
+    type(dictionary)           :: dict
+
+    ! Parse test file.
+    call fileToDict(dict, './IntegrationTestFiles/testDictionaryNoNewline')
+
+    ! Retrieve stored integer.
+    call dict % get(tempInt, 'myInt')
+    @assertEqual(7, tempInt)
+
+    ! Retrieve pointer to sub-dictionary.
+    dictPtr => dict % getDictPtr('subDict')
+
+    ! Retrieve real stored in sub-dictionary.
+    call dictPtr % get(tempReal, 'myReal')
+    @assertEqual(1.5_defReal, tempReal)
+
+  end subroutine testFromFileNoTrailingNewline
 
 end module dictParser_iTest

--- a/DataStructures/Tests/dictParser_test.f90
+++ b/DataStructures/Tests/dictParser_test.f90
@@ -60,5 +60,30 @@ contains
 
   end subroutine testFromChar
 
+  !!
+  !! Character data ending with '}' produces a tape ending with '}}' once the
+  !! padding workaround is removed. This tests that the parser handles it.
+  !!
+@Test
+  subroutine testFromCharEndingWithBrace()
+    class(dictionary), pointer :: dictPtr
+    integer(shortInt)          :: tempInt
+    type(dictionary)           :: dict
+
+    ! Parse input tape.
+    call charToDict(dict, "myInt 7; subDict { myInt 3; }")
+
+    ! Retrieve stored integer.
+    call dict % get(tempInt, 'myInt')
+    @assertEqual(7, tempInt)
+
+    ! Retrieve pointer to sub-dictionary.
+    dictPtr => dict % getDictPtr('subDict')
+
+    ! Retrieve integer stored in sub-dictionary.
+    call dictPtr % get(tempInt, 'myInt')
+    @assertEqual(3, tempInt)
+
+  end subroutine testFromCharEndingWithBrace
 
 end module dictParser_test

--- a/DataStructures/dictParser_func.f90
+++ b/DataStructures/dictParser_func.f90
@@ -220,8 +220,8 @@ contains
     ! Create document charTape
     call file % append(loc_data)
 
-    ! parseDict does not like '}}' ending so add an extra space
-    call file % append(' }' )
+    ! Append with dictionary terminator.
+    call file % append('}')
 
     ! Reinitialise dictionary
     call dict % kill()
@@ -270,7 +270,7 @@ contains
     character(100), parameter :: Here = 'parseDict (dictParser_func.f90)'
 
     ! Find next location & token
-    do while (pos < tape % length())
+    do while (pos <= tape % length())
       nextSymbol = tape % scanFrom(pos,';{}')
       if(nextSymbol == 0) call fatalError(Here,"There are tokens ';{}' in the charTape!'")
       fin = pos + nextSymbol - 1

--- a/IntegrationTestFiles/testDictionaryNoNewline
+++ b/IntegrationTestFiles/testDictionaryNoNewline
@@ -1,0 +1,1 @@
+myInt 7; subDict { myReal 1.5; }


### PR DESCRIPTION
## Mechanism

`dictParser_func.f90` parses a file by streaming its contents into a `charTape` (`readFileContents`, which converts each
end-of-record to a space—noted in the code itself at :74), appending the top-level dictionary terminator (:162-163):

```fortran
    ! Append with dictionary terminator
    call file % append('}')
```

and walking the tape with (:273):

```fortran
    do while (pos < tape % length())
```

For a file that ends with a newline, the converted trailing space sits between the last token and the appended `'}'`, so the loop condition still holds when the terminator is scanned. For a valid input file whose last line has no trailing newline, the appended `'}'` lands at *exactly* `tape % length()` with the previous token immediately before it: after that token is consumed, `pos == length`, the strict `<` exits the loop with the terminator unconsumed, and the parse aborts with:

```
End of file was reached without finding a termination symbol for a subdictionary. It means that '}' must be missing somewhere.
```

The same off-by-one is why `charToDict` carries an explicit workaround (:223-224):

```fortran
    ! parseDict does not like '}}' ending so add an extra space
    call file % append(' }' )
```

with the leading space existing only to keep the terminator off the exact end of the tape when the caller's data itself ends in `'}'`.

## Impact

Any input file whose final line lacks a newline is affected. The abort fires on an otherwise valid command-line invocation
(`scone.f90:50` feeds the path straight to `fileToDict`), with an error message pointing at a missing `'}'` that is, in fact, present.

## Provenance

Present since `ed517f67` ("New dictionary parser", 2020-03-14).

## Reproduction

```
printf 'a 1;' > f.txt        # no trailing newline
```

`fileToDict` on `f.txt` (e.g., via `./Build/scone.out f.txt`) aborts with the message above.

## Fix

Two small changes. First, fix the loop bound to include tape % length when parsing:

```fortran
    do while (pos <= tape % length())
```

and, in `charToDict`, the workaround is removed to match `fileToDict`:

```fortran
    ! Append with dictionary terminator.
    call file % append('}')
```

Note that this only makes the final position a valid starting position for the scan; it does **not** weaken any termination check. If an inner dictionary is genuinely unterminated, it consumes the top-level terminator early and the outer parse still reaches the same fatalError; a `'{'` at the tape end still errors in the recursive call.

## Test plan

First, a new integration test file, `IntegrationTestFiles/testDictionaryNoNewline`, whose content ends in `'}'` with no trailing newline (git records and preserves the missing end-of-line).

Second, two new tests attached to the PR:

- `testFromFileNoTrailingNewline` in `dictParser_iTest.f90` asserting the above file parses. On current `main` this test aborts with the error message above.
- A `charToDict` case with data ending exactly in `'}'` in `dictParser_test.f90` that explicitly tests the workaround removal. (Note: the existing `testFromChar` tape also ends in `'}'` and doubles as a regression for this path.)